### PR TITLE
FHIR version support (IG version and ViewDefinition resource version)

### DIFF
--- a/input/fsh/models.fsh
+++ b/input/fsh/models.fsh
@@ -47,10 +47,10 @@ criteria are defined by FHIRPath expressions.
   The FHIR resource that the view is based upon, e.g. 'Patient' or 'Observation'.
 """
 * resource from http://hl7.org/fhir/ValueSet/resource-types
-* resourceVersion 1..* code "FHIR version(s) of the resource for the ViewDefinition" """
+* resourceVersion 0..* code "FHIR version(s) of the resource for the ViewDefinition" """
   The FHIR version(s) for the FHIR resource. The value of this element is the
   formal version of the specification, without the revision number, e.g.
-  [publication].[major].[minor], which is 4.6.0. for this version.
+  [publication].[major].[minor].
 """
 * resourceVersion from http://hl7.org/fhir/ValueSet/FHIR-version
 * constant 0..* BackboneElement "Constant that can be used in FHIRPath expressions" """

--- a/input/fsh/models.fsh
+++ b/input/fsh/models.fsh
@@ -43,10 +43,16 @@ criteria are defined by FHIRPath expressions.
 * description 0..1 markdown "Natural language description of the view definition"
 * useContext 0..* UsageContext "The context that the content is intended to support"
 * copyright 0..1 markdown "Use and/or publishing restrictions"
-* resource 1..1 code "FHIR Resource for the ViewDefinition" """
+* resource 1..1 code "FHIR resource for the ViewDefinition" """
   The FHIR resource that the view is based upon, e.g. 'Patient' or 'Observation'.
 """
 * resource from http://hl7.org/fhir/ValueSet/resource-types
+* resourceVersion 1..* code "FHIR version(s) of the resource for the ViewDefinition" """
+  The FHIR version(s) for the FHIR resource. The value of this element is the
+  formal version of the specification, without the revision number, e.g.
+  [publication].[major].[minor], which is 4.6.0. for this version.
+"""
+* resourceVersion from http://hl7.org/fhir/ValueSet/FHIR-version
 * constant 0..* BackboneElement "Constant that can be used in FHIRPath expressions" """
   A constant is a string that is injected into a FHIRPath expression through the use of a FHIRPath 
   external constant with the same name.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -10,7 +10,7 @@ title: SQL on FHIR
 # description: Example Implementation Guide for getting started with SUSHI
 status: draft # draft | active | retired | unknown
 version: 0.0.1-pre
-fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
+fhirVersion: 5.0.0 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2023+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html


### PR DESCRIPTION
Based on https://chat.fhir.org/#narrow/stream/179219-analytics-on-FHIR/topic/Logical.20model.20representation/near/388365433

1. Make the IG use FHIR R5
2. Add a `resourceVersion 1..*` to ViewDefinition