### PR TITLE
Add .table-data class for classy tables

### DIFF
--- a/custom-template/content/assets/css/sof.css
+++ b/custom-template/content/assets/css/sof.css
@@ -48,3 +48,22 @@ p, li {
 #family-nav {
   padding-right: 15px;
 }
+
+.table-data thead th {
+  border-bottom: 1px solid #000;
+  padding: 5px 10px;
+}
+
+.table-data tbody td {
+  border-bottom: 1px dotted #ddd;
+  padding: 5px 10px;
+}
+
+.table-data tbody tr:hover td {
+  background-color: #ffffe0;
+}
+
+.table-data {
+  min-width: 80%;
+  margin-bottom: 2em;
+}

--- a/input/pagecontent/Binary-PatientAddresses-notes.md
+++ b/input/pagecontent/Binary-PatientAddresses-notes.md
@@ -7,3 +7,4 @@ This will result in a table like:
 | 2          | 789 Brookside Ave\nApt 3 | home     | Los Angeles | 90001 |
 | 3          | 987 Pinehurst Rd\nApt 4  | home     | Chicago     | 60601 |
 | 3          | 654 Evergreen Tce\nApt 5 | work     | Houston     | 77001 |
+{:.table-data}

--- a/input/pagecontent/Binary-PatientDemographics-notes.md
+++ b/input/pagecontent/Binary-PatientDemographics-notes.md
@@ -5,3 +5,4 @@ The resulting table will look like this:
 | 1  | female | Malvina Gerda | Vicario     |
 | 2  | male   | Yolotzin Adel | Bristow     |
 | 3  | other  | Jin Gomer     | Aarens      |
+{:.table-data}

--- a/input/pagecontent/Binary-UsCoreBloodPressures-notes.md
+++ b/input/pagecontent/Binary-UsCoreBloodPressures-notes.md
@@ -7,3 +7,4 @@ This will result in a table like:
 | 3  | 2          | 2020-01-03T00:00:00 | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 140                | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 100                |
 | 4  | 3          | 2020-01-04T00:00:00 | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 150                | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 110                |
 | 5  | 3          | 2020-01-05T00:00:00 | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 160                | http://unitsofmeasure.org | mmHg              | mm[Hg]               | 120                |
+{:.table-data}

--- a/input/pagecontent/tech-matrix.md
+++ b/input/pagecontent/tech-matrix.md
@@ -14,6 +14,7 @@ JSON Database Features:
 | Snowflake    | yes     | yes      | yes       | yes                 | no             | no          |
 | Athena SQL   | yes     | yes      | yes       | yes                 | no             | no          |
 | DuckDB       | no      | no       | yes       | no                  | no             | no          |
+{:.table-data}
 
 
 Schemas & Formats datatypes:


### PR DESCRIPTION
Cosmetic change to make data tables (in examples) a bit nicer to look at.

After a table, add `{:.table-data}` to add the class.

Patient view example:
<img width="607" alt="image" src="https://github.com/FHIR/sql-on-fhir-v2/assets/5303/68612c0b-58f6-4032-b389-a0e0cd43c2ec">


Tech matrix table (with hover state on SQLite)
<img width="958" alt="image" src="https://github.com/FHIR/sql-on-fhir-v2/assets/5303/a76019a0-f1e8-419d-a176-aedb4d3da91b">

