### PR TITLE
Scroll when .table-data is too wide

### DIFF
--- a/custom-template/content/assets/css/sof.css
+++ b/custom-template/content/assets/css/sof.css
@@ -49,6 +49,16 @@ p, li {
   padding-right: 15px;
 }
 
+.table-data {
+  min-width: 80%;
+  margin-bottom: 2em;
+}
+
+div:has(.table-data) {
+  overflow-x: scroll;
+  width: 100%;
+}
+
 .table-data thead th {
   border-bottom: 1px solid #000;
   padding: 5px 10px;
@@ -63,7 +73,3 @@ p, li {
   background-color: #ffffe0;
 }
 
-.table-data {
-  min-width: 80%;
-  margin-bottom: 2em;
-}


### PR DESCRIPTION
CSS to scroll if `.table-data` is too wide.


https://github.com/FHIR/sql-on-fhir-v2/assets/5303/7f5bbaab-7923-4643-8365-415d892e72f4

