### PR TITLE
Fixed a link syntax and a confusing statement about select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ node_modules
 /temp
 /template.tests
 /template
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws

--- a/input/pagecontent/StructureDefinition-ViewDefinition-intro.md
+++ b/input/pagecontent/StructureDefinition-ViewDefinition-intro.md
@@ -13,8 +13,8 @@ views of patients, unrolling patient addresses into an address table, specific v
 observations, and so on. 
 
 #### The selected fields
-The ViewDefinition has a [select](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select) structure that uses [FHIRPath]
-(https://hl7.org/fhirpath/)  expressions to select fields from the FHIR structure and place them in the column with the specified name.
+The ViewDefinition has a [select](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select) structure that uses
+[FHIRPath](https://hl7.org/fhirpath/) expressions to select fields from the FHIR structure and place them in the column with the specified name.
 
 
 #### The "where" criteria

--- a/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
+++ b/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
@@ -256,8 +256,7 @@ The multiple rows produced by `forEach`-style selects are joined to others with 
 
 * Parent/child selects will repeat values from the parent select for each item in the child select. 
 * Sibling select expressions are effectively cross joined, where each row in each `select` is duplicated for every row
-in sibling `select`s. (In practice, however, a given `select` in a ViewDefinition will produce only a single row
-for the resource.)
+in sibling `select`s.
 
 The [example view definitions](StructureDefinition-ViewDefinition-examples.html) illustrate this behavior.
 


### PR DESCRIPTION
This also includes some updates to `.gitignore` for IntelliJ.