### PR TITLE
Fix nested union test expectations

### DIFF
--- a/sof-js/tests/4_union.test.js
+++ b/sof-js/tests/4_union.test.js
@@ -1,10 +1,5 @@
-import { describe } from "bun:test";
-import {
-  start_case,
-  end_case,
-  add_test,
-  add_throwing_test
-} from './test_helpers.js'
+import { describe } from 'bun:test'
+import { add_test, add_throwing_test, end_case, start_case } from './test_helpers.js'
 
 let resources = [
   {
@@ -13,27 +8,27 @@ let resources = [
     telecom: [
       { value: 't1.1', system: 'phone' },
       { value: 't1.2', system: 'fax' },
-      { value: 't1.3', system: 'email' }
+      { value: 't1.3', system: 'email' },
     ],
     contact: [
       {
-        telecom: [{ value: 't1.c1.1', system: 'pager' }]
+        telecom: [{ value: 't1.c1.1', system: 'pager' }],
       },
       {
         telecom: [
           { value: 't1.c2.1', system: 'url' },
-          { value: 't1.c2.2', system: 'sms' }
-        ]
-      }
-    ]
+          { value: 't1.c2.2', system: 'sms' },
+        ],
+      },
+    ],
   },
   {
     resourceType: 'Patient',
     id: 'pt2',
     telecom: [
       { value: 't2.1', system: 'phone' },
-      { value: 't2.2', system: 'fax' }
-    ]
+      { value: 't2.2', system: 'fax' },
+    ],
   },
   {
     resourceType: 'Patient',
@@ -42,39 +37,37 @@ let resources = [
       {
         telecom: [
           { value: 't3.c1.1', system: 'email' },
-          { value: 't3.c1.2', system: 'pager' }
-        ]
+          { value: 't3.c1.2', system: 'pager' },
+        ],
       },
       {
-        telecom: [
-          { value: 't3.c2.1', system: 'sms' }
-        ]
-      }
-    ]
+        telecom: [{ value: 't3.c2.1', system: 'sms' }],
+      },
+    ],
   },
   {
     resourceType: 'Patient',
-    id: 'pt4'
-  }
+    id: 'pt4',
+  },
 ]
 
 start_case('union', 'TBD', resources)
 
 // TODO: duplicates in union
 
-describe("union", () => {
+describe('union', () => {
   let result = [
-    {tel: "t1.1",    sys: "phone",    id: "pt1"},
-    {tel: "t1.2",    sys: "fax",    id: "pt1"},
-    {tel: "t1.3",    sys: "email",    id: "pt1"},
-    {tel: "t1.c1.1", sys: "pager", id: "pt1"},
-    {tel: "t1.c2.1", sys: "url", id: "pt1"},
-    {tel: "t1.c2.2", sys: "sms", id: "pt1"},
-    {tel: "t2.1",    sys: "phone",    id: "pt2"},
-    {tel: "t2.2",    sys: "fax",    id: "pt2"},
-    {tel: "t3.c1.1", sys: "email", id: "pt3"},
-    {tel: "t3.c1.2", sys: "pager", id: "pt3"},
-    {tel: "t3.c2.1", sys: "sms", id: "pt3"}
+    { tel: 't1.1', sys: 'phone', id: 'pt1' },
+    { tel: 't1.2', sys: 'fax', id: 'pt1' },
+    { tel: 't1.3', sys: 'email', id: 'pt1' },
+    { tel: 't1.c1.1', sys: 'pager', id: 'pt1' },
+    { tel: 't1.c2.1', sys: 'url', id: 'pt1' },
+    { tel: 't1.c2.2', sys: 'sms', id: 'pt1' },
+    { tel: 't2.1', sys: 'phone', id: 'pt2' },
+    { tel: 't2.2', sys: 'fax', id: 'pt2' },
+    { tel: 't3.c1.1', sys: 'email', id: 'pt3' },
+    { tel: 't3.c1.2', sys: 'pager', id: 'pt3' },
+    { tel: 't3.c2.1', sys: 'sms', id: 'pt3' },
   ]
 
   // debug(unionAll, resources);
@@ -91,22 +84,22 @@ describe("union", () => {
               forEach: 'telecom',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }
-              ]
+                { name: 'sys', path: 'system' },
+              ],
             },
             {
               forEach: 'contact.telecom',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }
-              ]
-            }
-          ]
-        }
-      ]
+                { name: 'sys', path: 'system' },
+              ],
+            },
+          ],
+        },
+      ],
     },
-    expect: result
-  });
+    expect: result,
+  })
 
   add_test({
     title: 'unionAll + column',
@@ -121,20 +114,22 @@ describe("union", () => {
               forEach: 'telecom',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }]},
+                { name: 'sys', path: 'system' },
+              ],
+            },
             {
               forEach: 'contact.telecom',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }
-              ]
-            }
-          ]
-        }
-      ]
+                { name: 'sys', path: 'system' },
+              ],
+            },
+          ],
+        },
+      ],
     },
-    expect: result
-  });
+    expect: result,
+  })
 
   let unionDups = {
     resource: 'Patient',
@@ -147,35 +142,35 @@ describe("union", () => {
             forEach: 'telecom',
             column: [
               { name: 'tel', path: 'value' },
-              { name: 'sys', path: 'system' }
-            ]
+              { name: 'sys', path: 'system' },
+            ],
           },
           {
             forEach: 'telecom',
             column: [
               { name: 'tel', path: 'value' },
-              { name: 'sys', path: 'system' }
-            ]
-          }
-        ]
-      }
-    ]
-  };
+              { name: 'sys', path: 'system' },
+            ],
+          },
+        ],
+      },
+    ],
+  }
 
   let dups_result = [
-    { tel: "t1.1", sys: "phone", id: "pt1" },
-    { tel: "t1.2", sys: "fax", id: "pt1" },
-    { tel: "t1.3", sys: "email", id: "pt1" },
-    { tel: "t1.1", sys: "phone", id: "pt1" },
-    { tel: "t1.2", sys: "fax", id: "pt1" },
-    { tel: "t1.3", sys: "email", id: "pt1" },
-    { tel: "t2.1", sys: "phone", id: "pt2" },
-    { tel: "t2.2", sys: "fax", id: "pt2" },
-    { tel: "t2.1", sys: "phone", id: "pt2" },
-    { tel: "t2.2", sys: "fax", id: "pt2" }
-  ];
+    { tel: 't1.1', sys: 'phone', id: 'pt1' },
+    { tel: 't1.2', sys: 'fax', id: 'pt1' },
+    { tel: 't1.3', sys: 'email', id: 'pt1' },
+    { tel: 't1.1', sys: 'phone', id: 'pt1' },
+    { tel: 't1.2', sys: 'fax', id: 'pt1' },
+    { tel: 't1.3', sys: 'email', id: 'pt1' },
+    { tel: 't2.1', sys: 'phone', id: 'pt2' },
+    { tel: 't2.2', sys: 'fax', id: 'pt2' },
+    { tel: 't2.1', sys: 'phone', id: 'pt2' },
+    { tel: 't2.2', sys: 'fax', id: 'pt2' },
+  ]
 
-  add_test({ title: 'duplicates', view: unionDups, expect: dups_result });
+  add_test({ title: 'duplicates', view: unionDups, expect: dups_result })
 
   // TODO: add union with select
 
@@ -190,18 +185,18 @@ describe("union", () => {
           unionAll: [
             {
               forEach: 'name',
-              column: [{ name: 'given', path: 'given' }]
+              column: [{ name: 'given', path: 'given' }],
             },
             {
               forEach: 'name',
-              column: [{ name: 'given', path: 'given' }]
-            }
-          ]
-        }
-      ]
+              column: [{ name: 'given', path: 'given' }],
+            },
+          ],
+        },
+      ],
     },
-    expect: []
-  });
+    expect: [],
+  })
 
   add_test({
     title: 'empty with forEachOrNull',
@@ -214,27 +209,27 @@ describe("union", () => {
           unionAll: [
             {
               forEachOrNull: 'name',
-              column: [{ name: 'given', path: 'given' }]
+              column: [{ name: 'given', path: 'given' }],
             },
             {
               forEachOrNull: 'name',
-              column: [{ name: 'given', path: 'given' }]
-            }
-          ]
-        }
-      ]
+              column: [{ name: 'given', path: 'given' }],
+            },
+          ],
+        },
+      ],
     },
     expect: [
-      { given: null, id: "pt1" },
-      { given: null, id: "pt1" },
-      { given: null, id: "pt2" },
-      { given: null, id: "pt2" },
-      { given: null, id: "pt3" },
-      { given: null, id: "pt3" },
-      { given: null, id: "pt4" },
-      { given: null, id: "pt4" }
-    ]
-  });
+      { given: null, id: 'pt1' },
+      { given: null, id: 'pt1' },
+      { given: null, id: 'pt2' },
+      { given: null, id: 'pt2' },
+      { given: null, id: 'pt3' },
+      { given: null, id: 'pt3' },
+      { given: null, id: 'pt4' },
+      { given: null, id: 'pt4' },
+    ],
+  })
 
   add_test({
     title: 'forEachOrNull and forEach',
@@ -247,22 +242,22 @@ describe("union", () => {
           unionAll: [
             {
               forEach: 'name',
-              column: [{ name: 'given', path: 'given' }]
+              column: [{ name: 'given', path: 'given' }],
             },
             {
               forEachOrNull: 'name',
-              column: [{ name: 'given', path: 'given' }]
-            }
-          ]
-        }
-      ]
+              column: [{ name: 'given', path: 'given' }],
+            },
+          ],
+        },
+      ],
     },
     expect: [
-      { given: null, id: "pt1" },
-      { given: null, id: "pt2" },
-      { given: null, id: "pt3" },
-      { given: null, id: "pt4" },
-    ]
+      { given: null, id: 'pt1' },
+      { given: null, id: 'pt2' },
+      { given: null, id: 'pt3' },
+      { given: null, id: 'pt4' },
+    ],
   })
 
   add_test({
@@ -275,34 +270,76 @@ describe("union", () => {
           column: [{ name: 'id', path: 'id' }],
           unionAll: [
             {
-              forEach: 'telecom[0]',
-              column: [{ name: 'tel', path: 'value' }]
+              forEachOrNull: 'telecom[0]',
+              column: [{ name: 'tel', path: 'value' }],
             },
             {
               unionAll: [
                 {
-                  forEach: 'telecom[0]',
-                  column: [{ name: 'tel', path: 'value' }]
+                  forEachOrNull: 'telecom[0]',
+                  column: [{ name: 'tel', path: 'value' }],
                 },
                 {
-                  forEach: 'contact.telecom[0]',
-                  column: [{ name: 'tel', path: 'value' }]
-                }
-              ]
-            }
-          ]
-        }
-      ]
+                  forEachOrNull: 'contact.telecom[0]',
+                  column: [{ name: 'tel', path: 'value' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
     expect: [
-      { id: "pt1", tel: "t1.1" },
-      { id: "pt1", tel: "t1.1" },
-      { id: "pt1", tel: "t1.c1.1" },
-      { id: "pt2", tel: "t2.1" },
-      { id: "pt2", tel: "t2.1" },
-      { id: "pt3", tel: "t3.c1.1" }
-    ]
-  });
+      {
+        id: 'pt1',
+        tel: 't1.1',
+      },
+      {
+        id: 'pt1',
+        tel: 't1.1',
+      },
+      {
+        id: 'pt1',
+        tel: 't1.c1.1',
+      },
+      {
+        id: 'pt2',
+        tel: 't2.1',
+      },
+      {
+        id: 'pt2',
+        tel: 't2.1',
+      },
+      {
+        id: 'pt2',
+        tel: null,
+      },
+      {
+        id: 'pt3',
+        tel: null,
+      },
+      {
+        id: 'pt3',
+        tel: null,
+      },
+      {
+        id: 'pt3',
+        tel: 't3.c1.1',
+      },
+      {
+        id: 'pt4',
+        tel: null,
+      },
+      {
+        id: 'pt4',
+        tel: null,
+      },
+      {
+        id: 'pt4',
+        tel: null,
+      },
+    ],
+  })
 
   add_test({
     title: 'one empty operand',
@@ -317,29 +354,29 @@ describe("union", () => {
               forEach: 'telecom.where(false)',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }
-              ]
+                { name: 'sys', path: 'system' },
+              ],
             },
             {
               forEach: 'contact.telecom',
               column: [
                 { name: 'tel', path: 'value' },
-                { name: 'sys', path: 'system' }
-              ]
-            }
-          ]
-        }
-      ]
+                { name: 'sys', path: 'system' },
+              ],
+            },
+          ],
+        },
+      ],
     },
     expect: [
-      { id: "pt1", sys: "pager", tel: "t1.c1.1" },
-      { id: "pt1", sys: "url", tel: "t1.c2.1" },
-      { id: "pt1", sys: "sms", tel: "t1.c2.2" },
-      { id: "pt3", sys: "email", tel: "t3.c1.1" },
-      { id: "pt3", sys: "pager", tel: "t3.c1.2" },
-      { id: "pt3", sys: "sms", tel: "t3.c2.1" }
-    ]
-  });
+      { id: 'pt1', sys: 'pager', tel: 't1.c1.1' },
+      { id: 'pt1', sys: 'url', tel: 't1.c2.1' },
+      { id: 'pt1', sys: 'sms', tel: 't1.c2.2' },
+      { id: 'pt3', sys: 'email', tel: 't3.c1.1' },
+      { id: 'pt3', sys: 'pager', tel: 't3.c1.2' },
+      { id: 'pt3', sys: 'sms', tel: 't3.c2.1' },
+    ],
+  })
 
   add_throwing_test({
     title: 'column mismatch',
@@ -351,22 +388,22 @@ describe("union", () => {
           unionAll: [
             {
               column: [
-                {name: 'a', path: 'a'},
-                {name: 'b', path: 'b'}
-              ]
+                { name: 'a', path: 'a' },
+                { name: 'b', path: 'b' },
+              ],
             },
             {
               column: [
-                {name: 'a', path: 'a'},
-                {name: 'c', path: 'c'}
-              ]
-            }
-          ]
-        }
-      ]
+                { name: 'a', path: 'a' },
+                { name: 'c', path: 'c' },
+              ],
+            },
+          ],
+        },
+      ],
     },
-    expectError: true
-  });
+    expectError: true,
+  })
 
   // as per https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-ViewDefinition.html#unionall-column-requirements
   add_throwing_test({
@@ -379,23 +416,22 @@ describe("union", () => {
           unionAll: [
             {
               column: [
-                {name: 'a', path: 'a'},
-                {name: 'b', path: 'b'}
-              ]
+                { name: 'a', path: 'a' },
+                { name: 'b', path: 'b' },
+              ],
             },
             {
               column: [
-                {name: 'b', path: 'b'},
-                {name: 'a', path: 'a'}
-              ]
-            }
-          ]
-        }
-      ]
+                { name: 'b', path: 'b' },
+                { name: 'a', path: 'a' },
+              ],
+            },
+          ],
+        },
+      ],
     },
-    expectError: true
-  });
+    expectError: true,
+  })
 
   end_case()
-});
-
+})

--- a/sof-js/tests/4_union.test.js
+++ b/sof-js/tests/4_union.test.js
@@ -270,17 +270,17 @@ describe('union', () => {
           column: [{ name: 'id', path: 'id' }],
           unionAll: [
             {
-              forEachOrNull: 'telecom[0]',
+              forEach: 'telecom[0]',
               column: [{ name: 'tel', path: 'value' }],
             },
             {
               unionAll: [
                 {
-                  forEachOrNull: 'telecom[0]',
+                  forEach: 'telecom[0]',
                   column: [{ name: 'tel', path: 'value' }],
                 },
                 {
-                  forEachOrNull: 'contact.telecom[0]',
+                  forEach: 'contact.telecom[0]',
                   column: [{ name: 'tel', path: 'value' }],
                 },
               ],
@@ -301,42 +301,6 @@ describe('union', () => {
       {
         id: 'pt1',
         tel: 't1.c1.1',
-      },
-      {
-        id: 'pt2',
-        tel: 't2.1',
-      },
-      {
-        id: 'pt2',
-        tel: 't2.1',
-      },
-      {
-        id: 'pt2',
-        tel: null,
-      },
-      {
-        id: 'pt3',
-        tel: null,
-      },
-      {
-        id: 'pt3',
-        tel: null,
-      },
-      {
-        id: 'pt3',
-        tel: 't3.c1.1',
-      },
-      {
-        id: 'pt4',
-        tel: null,
-      },
-      {
-        id: 'pt4',
-        tel: null,
-      },
-      {
-        id: 'pt4',
-        tel: null,
       },
     ],
   })

--- a/tests/union.json
+++ b/tests/union.json
@@ -570,7 +570,7 @@
             ],
             "unionAll": [
               {
-                "forEach": "telecom[0]",
+                "forEachOrNull": "telecom[0]",
                 "column": [
                   {
                     "name": "tel",
@@ -581,7 +581,7 @@
               {
                 "unionAll": [
                   {
-                    "forEach": "telecom[0]",
+                    "forEachOrNull": "telecom[0]",
                     "column": [
                       {
                         "name": "tel",
@@ -590,7 +590,7 @@
                     ]
                   },
                   {
-                    "forEach": "contact.telecom[0]",
+                    "forEachOrNull": "contact.telecom[0]",
                     "column": [
                       {
                         "name": "tel",
@@ -626,8 +626,32 @@
           "tel": "t2.1"
         },
         {
+          "id": "pt2",
+          "tel": null
+        },
+        {
+          "id": "pt3",
+          "tel": null
+        },
+        {
+          "id": "pt3",
+          "tel": null
+        },
+        {
           "id": "pt3",
           "tel": "t3.c1.1"
+        },
+        {
+          "id": "pt4",
+          "tel": null
+        },
+        {
+          "id": "pt4",
+          "tel": null
+        },
+        {
+          "id": "pt4",
+          "tel": null
         }
       ]
     },

--- a/tests/union.json
+++ b/tests/union.json
@@ -570,7 +570,7 @@
             ],
             "unionAll": [
               {
-                "forEachOrNull": "telecom[0]",
+                "forEach": "telecom[0]",
                 "column": [
                   {
                     "name": "tel",
@@ -581,7 +581,7 @@
               {
                 "unionAll": [
                   {
-                    "forEachOrNull": "telecom[0]",
+                    "forEach": "telecom[0]",
                     "column": [
                       {
                         "name": "tel",
@@ -590,7 +590,7 @@
                     ]
                   },
                   {
-                    "forEachOrNull": "contact.telecom[0]",
+                    "forEach": "contact.telecom[0]",
                     "column": [
                       {
                         "name": "tel",
@@ -616,42 +616,6 @@
         {
           "id": "pt1",
           "tel": "t1.c1.1"
-        },
-        {
-          "id": "pt2",
-          "tel": "t2.1"
-        },
-        {
-          "id": "pt2",
-          "tel": "t2.1"
-        },
-        {
-          "id": "pt2",
-          "tel": null
-        },
-        {
-          "id": "pt3",
-          "tel": null
-        },
-        {
-          "id": "pt3",
-          "tel": null
-        },
-        {
-          "id": "pt3",
-          "tel": "t3.c1.1"
-        },
-        {
-          "id": "pt4",
-          "tel": null
-        },
-        {
-          "id": "pt4",
-          "tel": null
-        },
-        {
-          "id": "pt4",
-          "tel": null
         }
       ]
     },


### PR DESCRIPTION
I updated the expectations of the "union > nested" test, as I think they are incorrect.

My understanding is that `unionAll` is supposed to have inner join semantics, similar to `forEach`. This means that if an expression is not matched, the resource should be dropped from the result.