### PR TITLE
Fix incorrect type assertions within tests

### DIFF
--- a/tests/fhirpath_numbers.json
+++ b/tests/fhirpath_numbers.json
@@ -36,17 +36,17 @@
               {
                 "name": "add",
                 "path": "value.ofType(Range).low.value + value.ofType(Range).high.value",
-                "type": "integer"
+                "type": "decimal"
               },
               {
                 "name": "sub",
                 "path": "value.ofType(Range).high.value - value.ofType(Range).low.value",
-                "type": "integer"
+                "type": "decimal"
               },
               {
                 "name": "mul",
                 "path": "value.ofType(Range).low.value * value.ofType(Range).high.value",
-                "type": "integer"
+                "type": "decimal"
               },
               {
                 "name": "div",

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -91,7 +91,7 @@
               {
                 "path": "getResourceKey() = link.other.getReferenceKey(Observation)",
                 "name": "key_equal_ref",
-                "type": "string"
+                "type": "boolean"
               }
             ]
           }


### PR DESCRIPTION
There were a number of instances of incorrect type assertions within the test definitions.

The reference implementation does not care about these, but these need to be correct for implementations that opt in to more stringent comparison of asserted types to parsed/inferred types.