### PR TITLE
Removes quotes to make type parameter of getReferenceKey consistent

### DIFF
--- a/input/fsh/examples.fsh
+++ b/input/fsh/examples.fsh
@@ -156,7 +156,7 @@ Usage: #example
     * path = "getResourceKey()"
     * name = "id"
   * column[+]
-    * path = "subject.getReferenceKey('Patient')"
+    * path = "subject.getReferenceKey(Patient)"
     * name = "patient_id"
     * description = "Can be used to join to patient tables created by other views."
   * column[+]

--- a/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
+++ b/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
@@ -128,9 +128,9 @@ A view of  *Observation* resources would then have its own row key and a foreign
         "name": "id"
       },
       {
-        // The 'Patient' parameter is optional, but ensures the returned value
+        // The `Patient` parameter is optional, but ensures the returned value
         // will either be a patient row key or null.
-        "path": "subject.getReferenceKey('Patient')",
+        "path": "subject.getReferenceKey(Patient)",
         "name": "patient_id"
       }
     ]


### PR DESCRIPTION
In some examples we have quotes around the type parameter of `getReferenceKey`, e.g., `getReferenceKey('Patient')`, while in most other cases, including the test files, we don't (e.g., `getReferenceKey(Patient)`). This is to make these consistent which also makes it consistent with the `ofType` function of FHIRPath.