### PR TITLE
Fix Join test type and fn_reference_key expect

### DIFF
--- a/tests/fn_join.json
+++ b/tests/fn_join.json
@@ -85,7 +85,7 @@
               {
                 "path": "name.given.join()",
                 "name": "given",
-                "type": "name"
+                "type": "string"
               }
             ]
           }

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -47,7 +47,7 @@
           "key_equal_ref": true
         },
         {
-          "key_equal_ref": false
+          "key_equal_ref": null
         }
       ]
     },
@@ -72,7 +72,7 @@
           "key_equal_ref": true
         },
         {
-          "key_equal_ref": false
+          "key_equal_ref": null
         }
       ]
     },


### PR DESCRIPTION
The join test `join_with_empty_value` uses the type "name" (an invalid FHIR type) instead of "string".

[This Zulip Thread](https://chat.fhir.org/#narrow/stream/179219-analytics-on-FHIR/topic/fn_reference_keys.20unit.20test/near/435633465) explains the issue with the expected result of `false` rather than `null` for the two tests that I changed.