### PR TITLE
Fix types within constant tests

### DIFF
--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -429,7 +429,7 @@
         "constant": [
           {
             "name": "id_time",
-            "valueDate": "2016-11-12"
+            "valueDateTime": "2016-11-12"
           }
         ],
         "select": [
@@ -442,7 +442,7 @@
               },
               {
                 "name": "bool",
-                "path": "identified.ofType(DateTime) = %id_time",
+                "path": "identified.ofType(dateTime) = %id_time",
                 "type": "boolean"
               }
             ]

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -1,5 +1,5 @@
 {
-  "title": "constant types",
+  "title": "constant_types",
   "description": "tests for all types of constants",
   "resources": [
     {

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -764,7 +764,7 @@
               },
               {
                 "name": "bool",
-                "path": "value.ofType(Time) = %t",
+                "path": "value.ofType(time) = %t",
                 "type": "boolean"
               }
             ]

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -603,7 +603,7 @@
               },
               {
                 "name": "bool",
-                "path": "effective.ofType(Instant) = %eff",
+                "path": "effective.ofType(instant) = %eff",
                 "type": "boolean"
               }
             ]

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -523,7 +523,7 @@
         "constant": [
           {
             "name": "id",
-            "valueUuid": "id1"
+            "valueId": "id1"
           }
         ],
         "select": [

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -641,7 +641,7 @@
         "constant": [
           {
             "name": "oid",
-            "valueUrl": "urn:oid:1.0"
+            "valueOid": "urn:oid:1.0"
           }
         ],
         "select": [


### PR DESCRIPTION
There were some incorrect types within the constant tests:

- Type does not match type being tested
- Type used in `ofType` used upper camel case instead of lower, type specifiers are case-sensitive and can mean the difference between FHIR or FHIRPath types