### PR TITLE
Fix reference key tests

### DIFF
--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -85,11 +85,6 @@
           {
             "column": [
               {
-                "path": "link.other.getReferenceKey(Observation)",
-                "name": "referenceKey",
-                "type": "string"
-              },
-              {
                 "path": "getResourceKey() = link.other.getReferenceKey(Observation)",
                 "name": "key_equal_ref",
                 "type": "boolean"
@@ -100,11 +95,9 @@
       },
       "expect": [
         {
-          "referenceKey": null,
           "key_equal_ref": null
         },
         {
-          "referenceKey": null,
           "key_equal_ref": null
         }
       ]

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -48,7 +48,7 @@
           "key_equal_ref": true
         },
         {
-          "key_equal_ref": null
+          "key_equal_ref": false
         }
       ]
     },
@@ -73,7 +73,7 @@
           "key_equal_ref": true
         },
         {
-          "key_equal_ref": null
+          "key_equal_ref": false
         }
       ]
     },


### PR DESCRIPTION
I found a couple of problems with the reference key tests:

- Incorrect null expectations where the result should be false
- A column with an implementation-specific expectation in one of the tests