### PR TITLE
Add %rowIndex environment variable

### DIFF
--- a/input/fsh/examples/view-definition-examples.fsh
+++ b/input/fsh/examples/view-definition-examples.fsh
@@ -242,6 +242,37 @@ Usage: #example
     * path = "code"
     * name = "verification_status"
 
+Instance: PatientNamesWithIndex
+InstanceOf: ViewDefinition
+Description: """An example demonstrating the use of %rowIndex to capture the
+position of elements within a collection. This is useful for preserving FHIR
+ordering semantics and creating surrogate keys that combine resource ID with
+element position."""
+Usage: #example
+* name = "patient_names_with_index"
+* status = #draft
+* resource = #Patient
+* select[+]
+  * column[+]
+    * path = "getResourceKey()"
+    * name = "patient_id"
+* select[+]
+  * forEach = "name"
+  * column[+]
+    * path = "%rowIndex"
+    * name = "name_index"
+    * type = "integer"
+    * description = "The 0-based position of this name in the patient's name array."
+  * column[+]
+    * path = "use"
+    * name = "use"
+  * column[+]
+    * path = "family"
+    * name = "family"
+  * column[+]
+    * path = "given.join(' ')"
+    * name = "given"
+
 Instance: EncounterFlat
 InstanceOf: ViewDefinition
 Description: """A simple view for flattening an Encounter resource. Some of the

--- a/input/pagecontent/functional-model.md
+++ b/input/pagecontent/functional-model.md
@@ -224,14 +224,21 @@ primary difference is that `forEach` removes records where the FHIRPath
 expression returns no results, whereas `forEachOrNull` keeps an empty record in
 such cases.
 
+Both functions set the `%rowIndex` environment variable to the 0-based index
+of the current element within the collection being iterated. This allows
+columns to capture the position of each element for ordering or surrogate key
+purposes.
+
 Basic JavaScript implementation:
 
 ```javascript
-function forEach(path, expr, rows) {
+function forEach(path, expr, rows, envVars = {}) {
     return rows.flatMap((row) => {
-        return fhirpath(expr, row).map((item) => {
-            // evalKeyword will call column, select or other functions
-            return evalKeyword(expr, item);
+        return fhirpath(expr, row).map((item, index) => {
+            // Set %rowIndex for this iteration level.
+            const childEnvVars = { ...envVars, rowIndex: index };
+            // evalKeyword will call column, select or other functions.
+            return evalKeyword(expr, item, childEnvVars);
         });
     });
 }

--- a/openspec/changes/archive/2026-02-05-add-row-index-variable/design.md
+++ b/openspec/changes/archive/2026-02-05-add-row-index-variable/design.md
@@ -1,0 +1,126 @@
+# Design: %rowIndex environment variable
+
+## Context
+
+The SQL on FHIR specification allows unnesting of FHIR collections via `forEach`,
+`forEachOrNull`, and `repeat` directives. However, there is currently no way to
+capture the position of each element within the source collection. This
+information is valuable for:
+
+1. **Ordering semantics**: SQL result sets are unordered by default; including
+   the original index allows users to restore FHIR ordering.
+2. **Disambiguation**: When a Patient has multiple names, knowing which is the
+   first vs second can be semantically important.
+3. **Surrogate keys**: Combining resource ID with element index creates a unique
+   identifier for each row.
+
+### FHIRPath precedent
+
+The FHIRPath specification defines `$index` as an iteration variable available
+within functions like `where()` and `select()`. However, SQL on FHIR uses a
+restricted FHIRPath subset and does not expose `$index` directly.
+
+We propose introducing `%rowIndex` as a new environment variable (using the `%`
+prefix consistent with existing constants like `%bp_code`) rather than exposing
+`$index` directly. This keeps the mechanism aligned with how SQL on FHIR already
+handles external values.
+
+## Goals / Non-goals
+
+### Goals
+
+- Provide a portable, standardised way to access iteration position.
+- Support nested iteration with independent index tracking per level.
+- Integrate cleanly with existing constant/environment variable mechanisms.
+- Maintain backwards compatibility (existing ViewDefinitions unchanged).
+
+### Non-goals
+
+- Expose the full FHIRPath `$index` variable (out of scope for restricted
+  subset).
+- Provide named/scoped indices for parent iteration levels (e.g., `%rowIndex[1]`).
+- Track indices across `unionAll` branches (each branch maintains its own
+  iteration).
+
+## Decisions
+
+### Decision 1: Use `%rowIndex` rather than `$index`
+
+**Rationale**: SQL on FHIR already uses the `%name` syntax for constants and
+environment variables. Using `%rowIndex` keeps the mechanism consistent and
+avoids confusion with the full FHIRPath `$index` which has broader semantics.
+
+**Alternatives considered**:
+
+- `$index`: Would require documenting that SQL on FHIR's `$index` differs from
+  FHIRPath's `$index` (which is scoped to `where()`, `select()`, etc.).
+- `%index`: Shorter but less descriptive; `rowIndex` clarifies this is about row
+  generation.
+
+### Decision 2: 0-based indexing
+
+**Rationale**: Consistent with FHIRPath's `$index` (0-based), JavaScript arrays,
+and most programming languages. Also aligns with SQL's `ROW_NUMBER() - 1`
+pattern.
+
+**Alternatives considered**:
+
+- 1-based indexing: More natural for end users but inconsistent with FHIRPath
+  and would require conversion when joining with external data.
+
+### Decision 3: Each nesting level has independent `%rowIndex`
+
+**Rationale**: Nested `forEach` blocks operate on different collections. Each
+level should track its own position independently. Users can capture parent-level
+indices in separate columns if needed.
+
+**Example**:
+
+```json
+{
+  "forEach": "contact",
+  "column": [{ "name": "contact_index", "path": "%rowIndex" }],
+  "select": [{
+    "forEach": "telecom",
+    "column": [{ "name": "telecom_index", "path": "%rowIndex" }]
+  }]
+}
+```
+
+This produces `contact_index` from the outer loop and `telecom_index` from the
+inner loop.
+
+### Decision 4: Top-level `%rowIndex` is 0
+
+**Rationale**: At the resource level (no `forEach`), each resource produces one
+row. Returning 0 is consistent with "this is the 0th (only) iteration" and avoids
+null/undefined semantics.
+
+### Decision 5: `%rowIndex` type is `integer`
+
+**Rationale**: Indices are inherently integer values. This maps to SQL `INT` per
+the existing type mapping table.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Implementers may find index tracking complex in `repeat` | Provide clear algorithm description and test cases |
+| Users may expect named parent indices | Document the pattern of capturing indices in columns at each level |
+| Performance overhead of tracking indices | Minimal; implementations already iterate with counters internally |
+
+## Migration Plan
+
+No migration needed. This is a purely additive feature. Existing ViewDefinitions
+continue to work unchanged.
+
+## Open Questions
+
+1. **Should `%rowIndex` be `null` when `forEachOrNull` produces a null row?**
+   Proposed answer: No, use `0` for consistency. The null row is effectively the
+   "0th" item in an empty collection that was coerced to a single-element
+   collection.
+
+2. **Should this be a "shareable" feature or "experimental"?**
+   Proposed answer: Mark as shareable since it addresses a clear user need and
+   has straightforward semantics.

--- a/openspec/changes/archive/2026-02-05-add-row-index-variable/proposal.md
+++ b/openspec/changes/archive/2026-02-05-add-row-index-variable/proposal.md
@@ -1,0 +1,37 @@
+# Change: Add %rowIndex environment variable
+
+## Why
+
+When unnesting collections with `forEach`/`forEachOrNull`, users often need to know
+the position of each element within the original collection. This is useful for:
+
+- Preserving the original ordering semantics when joining flattened data.
+- Distinguishing between the first, second, third (etc.) occurrence of a
+  repeating element.
+- Creating surrogate keys that combine resource ID with element position.
+
+Currently there is no portable way to capture this information in SQL on FHIR
+ViewDefinitions. The FHIRPath specification defines `$index` for iteration
+contexts, but SQL on FHIR does not expose an equivalent mechanism.
+
+This proposal originates from a [community discussion on Zulip](https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Counting.20index.20in.20forEach).
+
+## What Changes
+
+- Add a new FHIRPath environment variable `%rowIndex` that returns the 0-based
+  index of the current element within the collection being iterated.
+- `%rowIndex` is available within `forEach`, `forEachOrNull`, and `repeat`
+  contexts.
+- At the top level (no iteration context), `%rowIndex` evaluates to `0`.
+- Each nesting level has its own independent `%rowIndex` value scoped to that
+  level's iteration.
+- The type of `%rowIndex` is `integer`.
+
+## Impact
+
+- Affected specs: New capability (no existing specs to modify).
+- Affected code:
+  - `input/pagecontent/StructureDefinition-ViewDefinition-notes.md` (documentation).
+  - `input/fsh/models.fsh` (potentially add to FHIRPath subset documentation).
+  - `sof-js/src/index.js` (reference implementation).
+  - `tests/` (new test file for %rowIndex).

--- a/openspec/changes/archive/2026-02-05-add-row-index-variable/specs/row-index/spec.md
+++ b/openspec/changes/archive/2026-02-05-add-row-index-variable/specs/row-index/spec.md
@@ -1,0 +1,82 @@
+# Row Index Environment Variable
+
+## ADDED Requirements
+
+### Requirement: %rowIndex environment variable availability
+
+View runners MUST support a `%rowIndex` environment variable that returns the
+0-based index of the current element within the collection being iterated by
+`forEach`, `forEachOrNull`, or `repeat`.
+
+#### Scenario: %rowIndex in forEach returns element position
+
+- **GIVEN** a Patient resource with multiple names.
+- **WHEN** a ViewDefinition uses `forEach: "name"` with a column
+  `path: "%rowIndex"`.
+- **THEN** the column contains `0` for the first name, `1` for the second name,
+  and so on.
+
+#### Scenario: %rowIndex in forEachOrNull with empty collection
+
+- **GIVEN** a Patient resource with no identifiers.
+- **WHEN** a ViewDefinition uses `forEachOrNull: "identifier"` with a column
+  `path: "%rowIndex"`.
+- **THEN** the single null row produced has `%rowIndex` equal to `0`.
+
+#### Scenario: %rowIndex at top level
+
+- **GIVEN** a Patient resource.
+- **WHEN** a ViewDefinition has no `forEach`/`forEachOrNull`/`repeat` and includes
+  a column `path: "%rowIndex"`.
+- **THEN** the column contains `0` for each resource row.
+
+---
+
+### Requirement: %rowIndex scoping in nested iterations
+
+Each `forEach`, `forEachOrNull`, or `repeat` context MUST have its own
+independent `%rowIndex` value. The `%rowIndex` in an inner iteration block
+reflects the position within the inner collection, not the outer collection.
+
+#### Scenario: Nested forEach with independent indices
+
+- **GIVEN** a Patient resource with 2 contacts, where the first contact has 3
+  telecoms and the second contact has 2 telecoms.
+- **WHEN** a ViewDefinition uses nested `forEach` blocks:
+  - Outer: `forEach: "contact"` with column `contact_idx` from `%rowIndex`.
+  - Inner: `forEach: "telecom"` with column `telecom_idx` from `%rowIndex`.
+- **THEN** the output rows have:
+  - `contact_idx=0, telecom_idx=0` (first contact, first telecom).
+  - `contact_idx=0, telecom_idx=1` (first contact, second telecom).
+  - `contact_idx=0, telecom_idx=2` (first contact, third telecom).
+  - `contact_idx=1, telecom_idx=0` (second contact, first telecom).
+  - `contact_idx=1, telecom_idx=1` (second contact, second telecom).
+
+---
+
+### Requirement: %rowIndex type
+
+The `%rowIndex` environment variable MUST evaluate to an `integer` type.
+
+#### Scenario: %rowIndex column type inference
+
+- **GIVEN** a ViewDefinition with a column defined as `path: "%rowIndex"` without
+  an explicit `type`.
+- **WHEN** the view runner infers the column type.
+- **THEN** the inferred type is `integer`.
+
+---
+
+### Requirement: %rowIndex in repeat
+
+When using the `repeat` directive, `%rowIndex` MUST reflect the position of the
+current node within the flattened sequence of all nodes visited during recursive
+traversal.
+
+#### Scenario: %rowIndex with repeat directive
+
+- **GIVEN** a QuestionnaireResponse with nested items at multiple levels.
+- **WHEN** a ViewDefinition uses `repeat: ["item", "answer.item"]` with a column
+  `path: "%rowIndex"`.
+- **THEN** the column contains sequential indices `0, 1, 2, ...` for each item
+  in the order they are visited during traversal.

--- a/openspec/changes/archive/2026-02-05-add-row-index-variable/tasks.md
+++ b/openspec/changes/archive/2026-02-05-add-row-index-variable/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## 1. Specification updates
+
+- [x] 1.1 Add `%rowIndex` documentation to
+      `input/pagecontent/StructureDefinition-ViewDefinition-notes.md` in a new
+      section under "Using Constants" or as part of a new "Environment Variables"
+      section.
+- [x] 1.2 Update the processing algorithm section to describe how `%rowIndex` is
+      set during iteration (step 2 of the recursive `Process(S, N)` algorithm).
+- [x] 1.3 Add `%rowIndex` to the FHIRPath subset documentation if a formal list
+      of supported environment variables exists.
+
+## 2. Test suite
+
+- [x] 2.1 Create `tests/row_index.json` with comprehensive test cases:
+  - Basic `forEach` with `%rowIndex` column.
+  - Basic `forEachOrNull` with `%rowIndex` column.
+  - Nested `forEach` demonstrating independent `%rowIndex` per level.
+  - `%rowIndex` at top level (should be 0).
+  - `%rowIndex` with `repeat` directive.
+  - `%rowIndex` combined with `unionAll`.
+- [x] 2.2 Validate new tests with `npm run validate`.
+
+## 3. Reference implementation (sof-js)
+
+- [x] 3.1 Update `sof-js/src/index.js` to track iteration index in `forEach`,
+      `forEachOrNull`, and `repeat` functions.
+- [x] 3.2 Update `sof-js/src/path.js` `fhirpath_evaluate` to accept and pass
+      `%rowIndex` as an environment variable to the fhirpath library.
+- [x] 3.3 Run `bun test` in `sof-js/` to verify all tests pass.
+
+## 4. Documentation
+
+- [x] 4.1 Add an example ViewDefinition to
+      `input/fsh/examples/view-definition-examples.fsh` demonstrating `%rowIndex`
+      usage.
+- [x] 4.2 Update the functional model documentation
+      (`input/pagecontent/functional-model.md`) if needed to explain `%rowIndex`
+      semantics.

--- a/openspec/specs/row-index/spec.md
+++ b/openspec/specs/row-index/spec.md
@@ -1,0 +1,84 @@
+# row-index Specification
+
+## Purpose
+TBD - created by archiving change add-row-index-variable. Update Purpose after archive.
+## Requirements
+### Requirement: %rowIndex environment variable availability
+
+View runners MUST support a `%rowIndex` environment variable that returns the
+0-based index of the current element within the collection being iterated by
+`forEach`, `forEachOrNull`, or `repeat`.
+
+#### Scenario: %rowIndex in forEach returns element position
+
+- **GIVEN** a Patient resource with multiple names.
+- **WHEN** a ViewDefinition uses `forEach: "name"` with a column
+  `path: "%rowIndex"`.
+- **THEN** the column contains `0` for the first name, `1` for the second name,
+  and so on.
+
+#### Scenario: %rowIndex in forEachOrNull with empty collection
+
+- **GIVEN** a Patient resource with no identifiers.
+- **WHEN** a ViewDefinition uses `forEachOrNull: "identifier"` with a column
+  `path: "%rowIndex"`.
+- **THEN** the single null row produced has `%rowIndex` equal to `0`.
+
+#### Scenario: %rowIndex at top level
+
+- **GIVEN** a Patient resource.
+- **WHEN** a ViewDefinition has no `forEach`/`forEachOrNull`/`repeat` and includes
+  a column `path: "%rowIndex"`.
+- **THEN** the column contains `0` for each resource row.
+
+---
+
+### Requirement: %rowIndex scoping in nested iterations
+
+Each `forEach`, `forEachOrNull`, or `repeat` context MUST have its own
+independent `%rowIndex` value. The `%rowIndex` in an inner iteration block
+reflects the position within the inner collection, not the outer collection.
+
+#### Scenario: Nested forEach with independent indices
+
+- **GIVEN** a Patient resource with 2 contacts, where the first contact has 3
+  telecoms and the second contact has 2 telecoms.
+- **WHEN** a ViewDefinition uses nested `forEach` blocks:
+  - Outer: `forEach: "contact"` with column `contact_idx` from `%rowIndex`.
+  - Inner: `forEach: "telecom"` with column `telecom_idx` from `%rowIndex`.
+- **THEN** the output rows have:
+  - `contact_idx=0, telecom_idx=0` (first contact, first telecom).
+  - `contact_idx=0, telecom_idx=1` (first contact, second telecom).
+  - `contact_idx=0, telecom_idx=2` (first contact, third telecom).
+  - `contact_idx=1, telecom_idx=0` (second contact, first telecom).
+  - `contact_idx=1, telecom_idx=1` (second contact, second telecom).
+
+---
+
+### Requirement: %rowIndex type
+
+The `%rowIndex` environment variable MUST evaluate to an `integer` type.
+
+#### Scenario: %rowIndex column type inference
+
+- **GIVEN** a ViewDefinition with a column defined as `path: "%rowIndex"` without
+  an explicit `type`.
+- **WHEN** the view runner infers the column type.
+- **THEN** the inferred type is `integer`.
+
+---
+
+### Requirement: %rowIndex in repeat
+
+When using the `repeat` directive, `%rowIndex` MUST reflect the position of the
+current node within the flattened sequence of all nodes visited during recursive
+traversal.
+
+#### Scenario: %rowIndex with repeat directive
+
+- **GIVEN** a QuestionnaireResponse with nested items at multiple levels.
+- **WHEN** a ViewDefinition uses `repeat: ["item", "answer.item"]` with a column
+  `path: "%rowIndex"`.
+- **THEN** the column contains sequential indices `0, 1, 2, ...` for each item
+  in the order they are visited during traversal.
+

--- a/sof-js/src/path.js
+++ b/sof-js/src/path.js
@@ -72,8 +72,21 @@ function process_constants(constants) {
   }, {})
 }
 
-export function fhirpath_evaluate(data, path, constants = []) {
-  return fhirpath.evaluate(data, rewrite_path(path), process_constants(constants), null, fhirpath_options)
+/**
+ * Evaluates a FHIRPath expression against data with support for constants and
+ * environment variables.
+ *
+ * @param {object} data - The FHIR data to evaluate against.
+ * @param {string} path - The FHIRPath expression to evaluate.
+ * @param {Array} constants - Array of constant definitions from the ViewDefinition.
+ * @param {object} envVars - Additional environment variables (e.g., { rowIndex: 0 }).
+ * @returns {Array} The result of the FHIRPath evaluation.
+ */
+export function fhirpath_evaluate(data, path, constants = [], envVars = {}) {
+  const context = process_constants(constants)
+  // Merge environment variables into context.
+  Object.assign(context, envVars)
+  return fhirpath.evaluate(data, rewrite_path(path), context, null, fhirpath_options)
 }
 
 export function fhirpath_validate(path) {

--- a/tests/row_index.json
+++ b/tests/row_index.json
@@ -1,0 +1,516 @@
+{
+  "title": "row_index",
+  "description": "%rowIndex environment variable for tracking element positions during iteration",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "Smith",
+          "given": ["John", "James"]
+        },
+        {
+          "family": "Jones",
+          "given": ["Jane"]
+        }
+      ],
+      "contact": [
+        {
+          "name": {
+            "family": "Contact1"
+          },
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "111-1111"
+            },
+            {
+              "system": "email",
+              "value": "a@example.com"
+            }
+          ]
+        },
+        {
+          "name": {
+            "family": "Contact2"
+          },
+          "telecom": [
+            {
+              "system": "phone",
+              "value": "222-2222"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "Brown"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    },
+    {
+      "resourceType": "QuestionnaireResponse",
+      "id": "qr1",
+      "item": [
+        {
+          "linkId": "1",
+          "text": "Group 1",
+          "item": [
+            {
+              "linkId": "1.1",
+              "text": "Question 1.1"
+            },
+            {
+              "linkId": "1.2",
+              "text": "Question 1.2"
+            }
+          ]
+        },
+        {
+          "linkId": "2",
+          "text": "Group 2"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "%rowIndex at top level",
+      "description": "At the resource level (no forEach), %rowIndex is 0 for each resource",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "row_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "row_index": 0
+        },
+        {
+          "id": "pt2",
+          "row_index": 0
+        },
+        {
+          "id": "pt3",
+          "row_index": 0
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with forEach",
+      "description": "Returns the 0-based index of each element in the iterated collection",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with forEachOrNull",
+      "description": "Returns the 0-based index; for empty collections, returns 0 for the null row",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEachOrNull": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        },
+        {
+          "id": "pt3",
+          "name_index": 0,
+          "family": null
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with nested forEach",
+      "description": "Each nesting level has its own independent %rowIndex value",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "contact",
+            "column": [
+              {
+                "name": "contact_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "contact_family",
+                "path": "name.family",
+                "type": "string"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "telecom",
+                "column": [
+                  {
+                    "name": "telecom_index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "system",
+                    "path": "system",
+                    "type": "code"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "contact_family": "Contact1",
+          "telecom_index": 0,
+          "system": "phone"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 0,
+          "contact_family": "Contact1",
+          "telecom_index": 1,
+          "system": "email"
+        },
+        {
+          "id": "pt1",
+          "contact_index": 1,
+          "contact_family": "Contact2",
+          "telecom_index": 0,
+          "system": "phone"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with repeat",
+      "description": "%rowIndex tracks the position within the flattened repeat traversal",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "QuestionnaireResponse",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "repeat": ["item"],
+            "column": [
+              {
+                "name": "item_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "linkId",
+                "path": "linkId",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "qr1",
+          "item_index": 0,
+          "linkId": "1"
+        },
+        {
+          "id": "qr1",
+          "item_index": 1,
+          "linkId": "1.1"
+        },
+        {
+          "id": "qr1",
+          "item_index": 2,
+          "linkId": "1.2"
+        },
+        {
+          "id": "qr1",
+          "item_index": 3,
+          "linkId": "2"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex with unionAll",
+      "description": "Each branch of unionAll maintains its own %rowIndex sequence",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "unionAll": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "name": "index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "value",
+                    "path": "family",
+                    "type": "string"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'name'",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "forEach": "contact",
+                "column": [
+                  {
+                    "name": "index",
+                    "path": "%rowIndex",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "value",
+                    "path": "name.family",
+                    "type": "string"
+                  },
+                  {
+                    "name": "source",
+                    "path": "'contact'",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "index": 0,
+          "value": "Smith",
+          "source": "name"
+        },
+        {
+          "id": "pt1",
+          "index": 1,
+          "value": "Jones",
+          "source": "name"
+        },
+        {
+          "id": "pt1",
+          "index": 0,
+          "value": "Contact1",
+          "source": "contact"
+        },
+        {
+          "id": "pt1",
+          "index": 1,
+          "value": "Contact2",
+          "source": "contact"
+        },
+        {
+          "id": "pt2",
+          "index": 0,
+          "value": "Brown",
+          "source": "name"
+        }
+      ]
+    },
+    {
+      "title": "%rowIndex for surrogate key",
+      "description": "Combining resource ID with %rowIndex to create a unique identifier for each row",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "forEach": "name",
+            "column": [
+              {
+                "name": "name_index",
+                "path": "%rowIndex",
+                "type": "integer"
+              },
+              {
+                "name": "family",
+                "path": "family",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "name_index": 0,
+          "family": "Smith"
+        },
+        {
+          "id": "pt1",
+          "name_index": 1,
+          "family": "Jones"
+        },
+        {
+          "id": "pt2",
+          "name_index": 0,
+          "family": "Brown"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `%rowIndex`, a new environment variable that returns the 0-based position of elements during `forEach`, `forEachOrNull`, and `repeat` iteration.

This addresses a gap identified in [community discussion](https://chat.fhir.org/#narrow/channel/179219-analytics-on-FHIR/topic/Counting.20index.20in.20forEach) - there was previously no portable way to capture element position when unnesting collections.

## Use cases

- **Preserving ordering**: SQL result sets are unordered; `%rowIndex` allows restoring FHIR ordering
- **Disambiguation**: Distinguish first vs second occurrence of repeating elements (e.g., multiple patient names)
- **Surrogate keys**: Combine resource ID with element position for unique row identifiers

## Behaviour

- Returns 0-based index within `forEach`, `forEachOrNull`, and `repeat` contexts
- At top level (no iteration), evaluates to `0`
- Each nesting level has independent `%rowIndex` values
- For `forEachOrNull` with empty collections, returns `0` for the null row
- Type is `integer`

## Example

```json
{
  "forEach": "name",
  "column": [
    { "name": "name_index", "path": "%rowIndex", "type": "integer" },
    { "name": "family", "path": "family", "type": "string" }
  ]
}
```

## Changes

- **Specification**: New "Environment Variables" section in ViewDefinition notes; updated processing algorithm
- **Tests**: `tests/row_index.json` with 7 test cases covering all iteration types
- **Reference implementation**: Updated `sof-js` to track and pass `%rowIndex` through iteration
- **Examples**: Added `PatientNamesWithIndex` ViewDefinition