### PR TITLE
Add ViewDefinition examples for repeat directive

### DIFF
--- a/input/fsh/examples/view-definition-examples.fsh
+++ b/input/fsh/examples/view-definition-examples.fsh
@@ -293,3 +293,86 @@ Usage: #example
     * path = "location.getReferenceKey(Location)"
     * name = "location_id"
 
+Instance: QuestionnaireResponseItems
+InstanceOf: ViewDefinition
+Description: """Demonstrates using the `repeat` directive to recursively flatten
+nested QuestionnaireResponse items. Unlike `forEach`, which only unnests a single
+level, `repeat` traverses all levels of nesting to produce one row per item
+regardless of depth. This is useful for analysing survey responses where questions
+may be grouped into nested sections."""
+Usage: #example
+* name = "questionnaire_response_items"
+* status = #draft
+* resource = #QuestionnaireResponse
+* select[+]
+  * column[+]
+    * path = "getResourceKey()"
+    * name = "id"
+    * description = "Unique questionnaire response identifier"
+  * column[+]
+    * path = "questionnaire"
+    * name = "questionnaire"
+    * description = "Canonical URL of the questionnaire"
+  * column[+]
+    * path = "subject.getReferenceKey(Patient)"
+    * name = "patient_id"
+    * description = "Patient identifier"
+  * column[+]
+    * path = "authored"
+    * name = "authored"
+    * description = "Date and time the response was authored"
+* select[+]
+  * repeat[+] = "item"
+  * column[+]
+    * path = "linkId"
+    * name = "item_link_id"
+    * description = "Unique identifier for this item within the questionnaire"
+  * column[+]
+    * path = "text"
+    * name = "item_text"
+    * description = "Question text"
+  * column[+]
+    * path = "answer.value.ofType(string)"
+    * name = "answer_value_string"
+    * description = "String answer value"
+  * column[+]
+    * path = "answer.value.ofType(integer)"
+    * name = "answer_value_integer"
+    * description = "Integer answer value"
+  * column[+]
+    * path = "answer.value.ofType(boolean)"
+    * name = "answer_value_boolean"
+    * description = "Boolean answer value"
+  * column[+]
+    * path = "answer.value.ofType(date)"
+    * name = "answer_value_date"
+    * description = "Date answer value"
+
+Instance: CodeSystemHierarchy
+InstanceOf: ViewDefinition
+Description: """Demonstrates using `repeat` with nested `select` to traverse a
+CodeSystem concept hierarchy. This produces parent-child code pairs by using
+`repeat` to walk down the concept tree and a nested `forEach` to extract each
+child concept at every level. Useful for building concept maps or analysing
+hierarchical terminologies."""
+Usage: #example
+* name = "code_system_hierarchy"
+* status = #draft
+* resource = #CodeSystem
+* select[+]
+  * column[+]
+    * path = "getResourceKey()"
+    * name = "id"
+    * description = "CodeSystem identifier"
+* select[+]
+  * repeat[+] = "concept"
+  * column[+]
+    * path = "code"
+    * name = "parent_code"
+    * description = "Code of the parent concept in the hierarchy"
+  * select[+]
+    * forEach = "concept"
+    * column[+]
+      * path = "code"
+      * name = "code"
+      * description = "Code of the child concept"

--- a/input/pagecontent/Binary-CodeSystemHierarchy-notes.md
+++ b/input/pagecontent/Binary-CodeSystemHierarchy-notes.md
@@ -1,0 +1,27 @@
+This will result in a "code_system_hierarchy" table that looks like this:
+
+| id  | parent_code | code      |
+|-----|-------------|-----------|
+| 1   | vehicle     | car       |
+| 1   | vehicle     | truck     |
+| 1   | vehicle     | motorbike |
+| 1   | car         | sedan     |
+| 1   | car         | suv       |
+| 1   | car         | hatchback |
+| 1   | truck       | pickup    |
+| 1   | truck       | semi      |
+{:.table-data}
+
+Given a CodeSystem with nested concepts like:
+
+- vehicle
+  - car
+    - sedan
+    - suv
+    - hatchback
+  - truck
+    - pickup
+    - semi
+  - motorbike
+
+The `repeat` directive walks down the concept tree, and at each level the nested `forEach` extracts each child concept. This produces parent-child pairs that can be used to build adjacency lists for hierarchical queries or to analyse the structure of a terminology.

--- a/input/pagecontent/Binary-QuestionnaireResponseItems-notes.md
+++ b/input/pagecontent/Binary-QuestionnaireResponseItems-notes.md
@@ -1,0 +1,15 @@
+This will result in a "questionnaire_response_items" table that looks like this:
+
+| id  | questionnaire                       | patient_id | authored                  | item_link_id | item_text          | answer_value_string | answer_value_integer | answer_value_boolean | answer_value_date |
+|-----|-------------------------------------|------------|---------------------------|--------------|--------------------|--------------------|---------------------|---------------------|------------------|
+| 1   | http://example.org/q/phq9           | 101        | 2024-03-15T10:30:00+10:00 | q1           | Little interest... | null               | 2                   | null                | null             |
+| 1   | http://example.org/q/phq9           | 101        | 2024-03-15T10:30:00+10:00 | q2           | Feeling down...    | null               | 1                   | null                | null             |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | demographics | Demographics       | null               | null                | null                | null             |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | name         | Full name          | John Smith         | null                | null                | null             |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | dob          | Date of birth      | null               | null                | null                | 1980-05-22       |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | conditions   | Medical conditions | null               | null                | null                | null             |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | diabetes     | Diabetes           | null               | null                | true                | null             |
+| 2   | http://example.org/q/health-history | 102        | 2024-03-16T14:20:00+10:00 | hypertension | Hypertension       | null               | null                | false               | null             |
+{:.table-data}
+
+Note how all items are flattened into a single table regardless of their nesting depth. The "demographics" and "conditions" items are group items (with no answer values), while items like "name", "dob", "diabetes", and "hypertension" are nested within those groups but appear as separate rows in the output.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -167,6 +167,14 @@ resources:
     extension:
       - url: http://hl7.org/fhir/tools/StructureDefinition/implementationguide-resource-logical
         valueString: https://sql-on-fhir.org/ig/StructureDefinition/ViewDefinition
+  Binary/QuestionnaireResponseItems:
+    extension:
+      - url: http://hl7.org/fhir/tools/StructureDefinition/implementationguide-resource-logical
+        valueString: https://sql-on-fhir.org/ig/StructureDefinition/ViewDefinition
+  Binary/CodeSystemHierarchy:
+    extension:
+      - url: http://hl7.org/fhir/tools/StructureDefinition/implementationguide-resource-logical
+        valueString: https://sql-on-fhir.org/ig/StructureDefinition/ViewDefinition
 
 #
 # Groups can control certain aspects of the IG generation.  The IG


### PR DESCRIPTION
Adds two new ViewDefinition examples demonstrating the `repeat` directive for recursive traversal of nested FHIR structures.

## Examples

**QuestionnaireResponseItems** - Flattens nested QuestionnaireResponse items at any depth, extracting linkId, question text, and answer values. Useful for analysing survey responses where questions may be grouped into nested sections.

**CodeSystemHierarchy** - Traverses CodeSystem concept hierarchies using `repeat` with a nested `forEach` to produce parent-child code pairs. Useful for building adjacency lists or analysing hierarchical terminologies.

Both examples include notes files with sample output tables showing the expected results.