### PR TITLE
Expand introduction with structured Solution, Examples, and API sections

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -9,7 +9,7 @@ the best available analytic tools regardless of the technology stack.
 ### Problem
 
 As the availability of FHIR data increases, there is a growing interest in
-using it for analytic purposes. However, to use FHIR effectively analysts
+using it for analytic purposes. However, to use FHIR effectively, analysts
 require a thorough understanding of the specification, including its
 conventions, semantics, and data types.
 
@@ -25,44 +25,82 @@ support reuse.
 
 ### Solution
 
-This specification provides: 1. A standard format for defining tabular, use
-case-specific views of FHIR data called `ViewDefinition`. Tools can be developed
-that use these views in queries capable of being executed on a wide variety of
-different query engines.
+This specification provides three complementary components to address these
+challenges:
 
-These views can be made available to users as an easier way to consume FHIR data
-which is simpler to understand and easier to process with generic analytic query
-tools.
+1. [**ViewDefinition**](#viewdefinition) — A portable format for defining
+   tabular views of FHIR data.
+2. [**SQLQuery**](#sqlquery) — A FHIR Library profile for representing
+   shareable, parameterized SQL queries.
+3. [**HTTP API**](#http-api) — Standard FHIR operations for running views
+   and queries.
+
+#### ViewDefinition
+
+A [ViewDefinition](StructureDefinition-ViewDefinition.html) is a standard
+format for defining tabular, use case-specific views of FHIR data. Each
+ViewDefinition is tied to a single FHIR resource type and uses
+[FHIRPath](https://hl7.org/fhirpath/) expressions to define columns, filters,
+and unnesting logic.
+
+These views can be made available to users as an easier way to consume FHIR
+data that is simpler to understand and easier to process with generic analytic
+query tools.
 
 FHIR implementation guides could include definitions of simple, flattened views
 that comprise essential data elements. The availability of these view
-definitions will greatly reduce the need for analysts to perform repetitive and
-redundant transformation tasks for common use cases.
+definitions would greatly reduce the need for analysts to perform repetitive
+and redundant transformation tasks for common use cases.
 
-2. A [profile](StructureDefinition-SQLQuery.html) for the FHIR Library resource
-type used to represent a single, logical SQL query consistent with the broader
-FHIR ecosystem e.g. the [Clinical
-Reasoning](https://hl7.org/fhir/clinicalreasoning-module.html) module.
+ViewDefinitions also support recursive traversal of arbitrarily nested
+structures (e.g., `QuestionnaireResponse` items) via the
+[`repeat`](StructureDefinition-ViewDefinition.html#recursive-traversal-with-repeat)
+directive, and expose a
+[`%rowIndex`](StructureDefinition-ViewDefinition.html#rowindex) environment
+variable that captures element position during iteration — useful for
+preserving FHIR ordering and creating surrogate keys.
 
-The profile supports query authors using native SQL workflows and implementers
-with the ability to represent multiple, dialect-specific versions of a single,
-logical SQL query enabling improved portability.
+See the [ViewDefinition](StructureDefinition-ViewDefinition.html) page for the
+full definition and additional examples.
 
-3. An [HTTP API](operations.html) for interacting with SQL on FHIR systems
-defined as FHIR OperationDefinitions. We expect a broad range of systems to
-implement the API including both general-purpose FHIR servers and more
-purpose-specific ViewDefinition "runners".
+#### SQLQuery
 
-The API supports a range of use cases including asynchronous bulk export
-(inspired by the FHIR [Bulk Data Access
-API](https://build.fhir.org/ig/HL7/bulk-data/en/)), "real-time" evaluation of
-ViewDefinitions with streamed results, and ViewDefinition authoring and
-validation.
+The [SQLQuery](StructureDefinition-SQLQuery.html) profile on the FHIR Library
+resource represents a single, logical SQL query within the FHIR ecosystem. It
+bridges the View Layer and the Analytics Layer: ViewDefinitions produce the
+flat tables, and SQLQuery joins and aggregates them using native SQL.
+
+The profile supports multiple dialect-specific SQL variants of the same logical
+query, parameterized queries with safe binding, and table aliases that map to
+ViewDefinition outputs. See the
+[SQLQuery profile](StructureDefinition-SQLQuery.html) for details.
+
+#### HTTP API
+
+The specification defines a standard [HTTP API](operations.html) as FHIR
+OperationDefinitions for interacting with SQL on FHIR systems:
+
+* [`$viewdefinition-run`](OperationDefinition-ViewDefinitionRun.html) —
+  Synchronous evaluation of a ViewDefinition with streamed results.
+* [`$viewdefinition-export`](OperationDefinition-ViewDefinitionExport.html) —
+  Asynchronous bulk export of ViewDefinition results into formats like CSV,
+  NDJSON, or Parquet.
+* [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) — Execute a
+  SQLQuery Library against materialized ViewDefinition tables synchronously.
+* `$sqlquery-export` — Asynchronous counterpart to `$sqlquery-run` for
+  large-scale query execution with results delivered to file storage.
+
+Servers advertise their supported operations via the standard FHIR
+[CapabilityStatement](operations-capability.html).
 
 
-Let's start with a simple example, defining a "patient_demographics" and "diagnoses" views with
-the following [ViewDefinition](StructureDefinition-ViewDefinition.html)
-structure:
+### Examples
+
+#### Simple Example
+
+Let's start with a simple example, defining "patient_demographics" and
+"diagnoses" views with the following
+[ViewDefinition](StructureDefinition-ViewDefinition.html) structure:
 
 ```json
 {
@@ -134,34 +172,81 @@ structure:
 
 Such tabular views can be created for any FHIR resource,
 with [more examples here](artifacts.html#example-example-instances). See
-the [View Definition page](StructureDefinition-ViewDefinition.html) for the full
-definition of the above structure.
+the [View Definition page](StructureDefinition-ViewDefinition.html) for the
+full definition of the above structure.
 
-The views can be persisted and queried in your database of choice, using the view
-name as the table name:
+#### Example with SQLQuery
+
+Once these views are materialized, they can be queried using a
+[SQLQuery](StructureDefinition-SQLQuery.html) Library resource. A SQLQuery
+declares its ViewDefinition dependencies, parameters, and the SQL itself as a
+single, shareable FHIR resource:
+
+```json
+{
+  "resourceType": "Library",
+  "meta": {
+    "profile": ["https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery"]
+  },
+  "type": {
+    "coding": [{
+      "system": "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+      "code": "sql-query"
+    }]
+  },
+  "name": "DiagnosisByAgeSummary",
+  "status": "active",
+  "relatedArtifact": [
+    {
+      "type": "depends-on",
+      "resource": "https://example.org/ViewDefinition/patient_demographics",
+      "label": "pt"
+    },
+    {
+      "type": "depends-on",
+      "resource": "https://example.org/ViewDefinition/diagnoses_view",
+      "label": "dg"
+    }
+  ],
+  "content": [{
+    "contentType": "application/sql",
+    "extension": [{
+      "url": "https://sql-on-fhir.org/ig/StructureDefinition/sql-text",
+      "valueString": "SELECT DATE_PART('year', AGE(pt.dob::timestamp)) AS age, pt.gender, dg.code, dg.display, count(*) FROM pt JOIN dg USING (patient_id) GROUP BY 1,2,3,4 ORDER BY 1, 5 DESC"
+    }],
+    "data": "U0VMRUNUIERBVEVfUEFSVCgneWVhcicsIEFHRShwdC5kb2I6OnRpbWVzdGFtcCkpIEFTIGFnZSwgcHQuZ2VuZGVyLCBkZy5jb2RlLCBkZy5kaXNwbGF5LCBjb3VudCgqKSBGUk9NIHB0IEpPSU4gZGcgVVNJTkcgKHBhdGllbnRfaWQpIEdST1VQIEJZIDEsMiwzLDQgT1JERVIgQlkgMSwgNSBERVND"
+  }]
+}
+```
+
+The `relatedArtifact` entries declare that this query depends on the
+`patient_demographics` and `diagnoses_view` ViewDefinitions, aliased as `pt`
+and `dg` respectively. The decoded SQL is:
 
 ```sql
- SELECT  DATE_PART('year', AGE(pt.dob::timestamp)) AS age,
-         gender,
-         dg.code,
-         dg.display,
-         count(*)
-    FROM patient_demographics pt
-    JOIN diagnoses dg using (patient_id)
-GROUP BY 1,2,3,4
-ORDER BY 1, 5 desc
+   SELECT DATE_PART('year', AGE(pt.dob::timestamp)) AS age,
+          pt.gender,
+          dg.code,
+          dg.display,
+          count(*)
+     FROM pt
+     JOIN dg USING (patient_id)
+ GROUP BY 1,2,3,4
+ ORDER BY 1, 5 DESC
 ```
 
 Example output:
 
-|age|	gender|code|display	countr|
-----|-------|----|--------------|
-|7| female| 444814009| Viral sinusitis (disorder)| 1340
-|7| female| 65363002| Otitis media| 2345
-|7| female| 43878008| Streptococcal sore throat (disorder)| 42
+| age | gender | code      | display                              | count |
+|-----|--------|-----------|--------------------------------------|-------|
+| 7   | female | 444814009 | Viral sinusitis (disorder)           | 1340  |
+| 7   | female | 65363002  | Otitis media                         | 2345  |
+| 7   | female | 43878008  | Streptococcal sore throat (disorder) | 42    |
 {:.table-data}
 
-
+This query can be executed via the
+[`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) operation, or used
+directly in any database where the views have been materialized.
 
 
 ### Non-goals
@@ -184,7 +269,7 @@ pipelines join as needed.
 #### View Definitions do not have sorting, aggregation, or limit capabilities
 
 View Definitions define only the logical schema of views, and therefore defer
-sorting, aggregation or limit operations to engines, along with cross-view
+sorting, aggregation, or limit operations to engines, along with cross-view
 joins. *View Runners* (described below) or future FHIR server operations may
 accept limits or sort columns as part of their operations, so users at runtime
 can specify what they need dynamically and independently of the definition of
@@ -216,54 +301,70 @@ system. A broader view of the system includes three layers:
 The Data Layer is a set of lossless representations that collectively enable
 FHIR to be used with a wide variety of different query technologies. 
 
-The Data Layer may optionally be persisted and annotated to make implementations
-of the View Layer more efficient, but no specific Data Layer structure will be
-required by this specification.
+The Data Layer may optionally be persisted and annotated to make
+implementations of the View Layer more efficient, but no specific Data Layer
+structure will be required by this specification.
 
 #### View Layer
 
 The View Layer defines portable, tabular views of FHIR data that can be easily
 consumed by a wide variety of analytic tools. The use of these tools is
-described in the Analytics Layer section. Our goal here is to get the
+described in the Analytics Layer section. The goal of this layer is to get the
 required FHIR data into a form that matches user needs and common analytic
 patterns.
 
 The View Layer has two key components:
 
-* *View Definitions*, allowing users to define flattened views of FHIR data that
-  are portable between systems.
-* *View Runners*, system-specific tools or libraries that apply view definitions
-  to the underlying data layer, optionally making use of annotations to optimize
-  performance.
+* *View Definitions*, allowing users to define flattened views of FHIR data
+  that are portable between systems.
+* *View Runners*, system-specific tools or libraries that apply view
+  definitions to the underlying data layer, optionally making use of
+  annotations to optimize performance.
 
-See [View Definition](StructureDefinition-ViewDefinition.html) for more details
-and examples.
+The [HTTP API](operations.html) formalizes the View Runner concept as standard
+FHIR operations:
+[`$viewdefinition-run`](OperationDefinition-ViewDefinitionRun.html) for
+synchronous evaluation and
+[`$viewdefinition-export`](OperationDefinition-ViewDefinitionExport.html) for
+asynchronous bulk export.
+
+See [View Definition](StructureDefinition-ViewDefinition.html) for more
+details and examples.
 
 View Runners will be specific to the data layer they use. Each data layer may
-have one or more corresponding view runners, but a given View Definition can be
-run by many runners over many data layers.
+have one or more corresponding view runners, but a given View Definition can
+be run by many runners over many data layers.
 
 There are two popular categories of runners:
-* **In-memory runner** consume resources, flatten, and output results into a stream, a file or a table.
-You can imagine the ETL pipeline from FHIR Bulk export ndjson files transformed into parquet files.
-* **In-database runner** translate ViewDefinition into SQL query over an FHIR-native database.
-In that case the view can be a real database view or table. In-database runner could be way more efficient than in-memory
-,speed and storage resources but much more complex for implementers.
+* **In-memory runners** consume resources, flatten, and output results into a
+  stream, a file or a table. You can imagine the ETL pipeline from FHIR Bulk
+  export ndjson files transformed into parquet files.
+* **In-database runners** translate ViewDefinition into SQL query over an
+  FHIR-native database. In that case the view can be a real database view or
+  table. In-database runners could be far more efficient than in-memory in
+  speed and storage resources but are much more complex for implementers.
 
 <img src="viewdef-runners.jpeg" alt="Diagram comparing in-memory and in-database runners" style="float: none; width: 100%">
 
 
 #### The Analytics Layer
 
-Users must be able to easily leverage the above views with the analytic tools of
-their choice. This specification purposefully does not define what these are,
-but common use cases may be SQL queries by consuming applications,
-dataframe-based data science tools in Python or R, or integration with business
-intelligence tools.
+Users must be able to easily leverage the above views with the analytic tools
+of their choice. This specification purposefully does not define what these
+are, but common use cases may be SQL queries by consuming applications,
+dataframe-based data science tools in Python or R, or integration with
+business intelligence tools.
+
+The [SQLQuery](StructureDefinition-SQLQuery.html) profile serves as a bridge
+between the View Layer and the Analytics Layer, capturing reusable SQL queries
+over ViewDefinition outputs as shareable FHIR Library resources. The
+[`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) operation executes
+these queries against materialized views.
 
 ### Glossary
 
-See the [Glossary](glossary.html) for the definitions of terms used in this specification.
+See the [Glossary](glossary.html) for the definitions of terms used in this
+specification.
 
 ### License
 


### PR DESCRIPTION
## Summary

Restructures the index.md introduction to better reflect the current state of the specification.

### Changes

- **Solution section**: Restructured from inline numbered list into proper subsections (ViewDefinition, SQLQuery, HTTP API) with a numbered overview list
- **ViewDefinition**: Mentions `repeat` directive and `%rowIndex` with links to docs
- **SQLQuery**: Concise description as a bridge between View Layer and Analytics Layer
- **HTTP API**: Bullet list of all operations including new `$sqlquery-export` (async counterpart to `$sqlquery-run`)
- **Examples section**: Separated into Simple Example (ViewDefinitions) and Example with SQLQuery (full Library JSON resource with decoded SQL and output)
- **System Layers**: Added API operations reference under View Layer, SQLQuery bridge under Analytics Layer
- **Minor grammar/style fixes**: comma after "effectively", Oxford comma, subject-verb agreement on runners, rewrapped prose to ~80 columns