### PR TITLE
Fix dateTime type in fn_boundary tests

### DIFF
--- a/tests/fn_boundary.json
+++ b/tests/fn_boundary.json
@@ -231,7 +231,7 @@
               {
                 "name": "date",
                 "path": "birthDate.lowBoundary()",
-                "type": "date"
+                "type": "dateTime"
               }
             ]
           }
@@ -261,7 +261,7 @@
               {
                 "name": "date",
                 "path": "birthDate.highBoundary()",
-                "type": "date"
+                "type": "dateTime"
               }
             ]
           }


### PR DESCRIPTION
The `date lowBoundary` and `date highBoundary` tests in `tests/fn_boundary.json` incorrectly declared `"type": "date"` on columns derived from `birthDate.lowBoundary()` and `birthDate.highBoundary()`. Applied to a `date`, these FHIRPath functions return a `dateTime`, so the column type should be `dateTime`.

The expected output values (`1970-06-01` / `1970-06-30`) remain valid as date-only-precision `dateTime` instances.

This same change was applied downstream in hapifhir/org.hl7.fhir.core@b8657af ("fix view definition tests"), where it resolved a ViewDefinition validation error in the R5 reference implementation.

Fixes #336.