### PR TITLE
Fix invalid FHIR resources in test data

### DIFF
--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -12,7 +12,9 @@
       "id": "d1",
       "udiCarrier": [
         {
-          "carrierAIDC": "aGVsbG8K"
+          "carrierAIDC": "aGVsbG8K",
+          "deviceIdentifier": "device-id",
+          "issuer": "issuer"
         }
       ]
     },
@@ -21,7 +23,9 @@
       "id": "d2",
       "udiCarrier": [
         {
-          "carrierAIDC": "YnllCg=="
+          "carrierAIDC": "YnllCg==",
+          "deviceIdentifier": "device-id",
+          "issuer": "issuer"
         }
       ]
     },

--- a/tests/constant_types.json
+++ b/tests/constant_types.json
@@ -49,7 +49,7 @@
       "resourceType": "ClaimResponse",
       "id": "cr1",
       "use": "claim",
-      "patient": { "reference": "Patient/p1" },
+      "patient": { "reference": "Patient/pt1" },
       "created": "2021-09-02",
       "insurer": { "reference": "Organization/o1" },
       "type": { "text": "type" },
@@ -70,7 +70,7 @@
       "resourceType": "ClaimResponse",
       "id": "cr2",
       "use": "claim",
-      "patient": { "reference": "Patient/p1" },
+      "patient": { "reference": "Patient/pt1" },
       "created": "2021-09-02",
       "insurer": { "reference": "Organization/o1" },
       "type": { "text": "type" },
@@ -91,7 +91,7 @@
       "resourceType": "ClaimResponse",
       "id": "cr3",
       "use": "claim",
-      "patient": { "reference": "Patient/p1" },
+      "patient": { "reference": "Patient/pt1" },
       "created": "2021-09-02",
       "insurer": { "reference": "Organization/o1" },
       "type": { "text": "type" },
@@ -155,21 +155,21 @@
       "resourceType": "ImagingStudy",
       "id": "is1",
       "status": "available",
-      "subject": { "reference": "Patient/p1" },
+      "subject": { "reference": "Patient/pt1" },
       "numberOfSeries": 9
     },
     {
       "resourceType": "ImagingStudy",
       "id": "is2",
       "status": "available",
-      "subject": { "reference": "Patient/p1" },
+      "subject": { "reference": "Patient/pt1" },
       "numberOfSeries": 12
     },
     {
       "resourceType": "ImagingStudy",
       "id": "is3",
       "status": "available",
-      "subject": { "reference": "Patient/p1" }
+      "subject": { "reference": "Patient/pt1" }
     },
     {
       "resourceType": "Measure",

--- a/tests/fhirpath.json
+++ b/tests/fhirpath.json
@@ -4,6 +4,11 @@
   "fhirVersion": ["5.0.0", "4.0.1"],
   "resources": [
     {
+      "resourceType": "Organization",
+      "id": "o1",
+      "name": "Test Organization"
+    },
+    {
       "resourceType": "Patient",
       "id": "pt1",
       "managingOrganization": {

--- a/tests/fn_boundary.json
+++ b/tests/fn_boundary.json
@@ -38,7 +38,7 @@
         "text": "code"
       },
       "status": "final",
-      "valueTime": "12:34"
+      "valueTime": "12:34:00"
     },
     {
       "resourceType": "Patient",

--- a/tests/fn_boundary.json
+++ b/tests/fn_boundary.json
@@ -37,6 +37,7 @@
       "code": {
         "text": "code"
       },
+      "status": "final",
       "valueTime": "12:34"
     },
     {

--- a/tests/fn_extension.json
+++ b/tests/fn_extension.json
@@ -88,8 +88,7 @@
         "profile": [
           "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         ]
-      },
-      "extension": []
+      }
     }
   ],
   "tests": [

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -5,9 +5,14 @@
   "resources": [
     {
       "resourceType": "Patient",
+      "id": "p3"
+    },
+    {
+      "resourceType": "Patient",
       "id": "p1",
       "link": [
         {
+          "type": "seealso",
           "other": {
             "reference": "Patient/p1"
           }
@@ -19,6 +24,7 @@
       "id": "p2",
       "link": [
         {
+          "type": "seealso",
           "other": {
             "reference": "Patient/p3"
           }

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -5,10 +5,6 @@
   "resources": [
     {
       "resourceType": "Patient",
-      "id": "p3"
-    },
-    {
-      "resourceType": "Patient",
       "id": "p1",
       "link": [
         {
@@ -56,9 +52,6 @@
         },
         {
           "key_equal_ref": false
-        },
-        {
-          "key_equal_ref": null
         }
       ]
     },
@@ -85,9 +78,6 @@
         },
         {
           "key_equal_ref": false
-        },
-        {
-          "key_equal_ref": null
         }
       ]
     },
@@ -109,9 +99,6 @@
         ]
       },
       "expect": [
-        {
-          "key_equal_ref": null
-        },
         {
           "key_equal_ref": null
         },

--- a/tests/fn_reference_keys.json
+++ b/tests/fn_reference_keys.json
@@ -56,6 +56,9 @@
         },
         {
           "key_equal_ref": false
+        },
+        {
+          "key_equal_ref": null
         }
       ]
     },
@@ -82,6 +85,9 @@
         },
         {
           "key_equal_ref": false
+        },
+        {
+          "key_equal_ref": null
         }
       ]
     },
@@ -103,6 +109,9 @@
         ]
       },
       "expect": [
+        {
+          "key_equal_ref": null
+        },
         {
           "key_equal_ref": null
         },

--- a/tests/repeat.json
+++ b/tests/repeat.json
@@ -6,6 +6,7 @@
     {
       "resourceType": "QuestionnaireResponse",
       "id": "qr1",
+      "status": "completed",
       "item": [
         {
           "linkId": "1",

--- a/tests/repeat.json
+++ b/tests/repeat.json
@@ -6,6 +6,7 @@
     {
       "resourceType": "QuestionnaireResponse",
       "id": "qr1",
+      "questionnaire": "http://example.com/Questionnaire/q1",
       "status": "completed",
       "item": [
         {

--- a/tests/row_index.json
+++ b/tests/row_index.json
@@ -61,6 +61,7 @@
     {
       "resourceType": "QuestionnaireResponse",
       "id": "qr1",
+      "status": "completed",
       "item": [
         {
           "linkId": "1",

--- a/tests/row_index.json
+++ b/tests/row_index.json
@@ -61,6 +61,7 @@
     {
       "resourceType": "QuestionnaireResponse",
       "id": "qr1",
+      "questionnaire": "http://example.com/Questionnaire/q1",
       "status": "completed",
       "item": [
         {

--- a/tests/where.json
+++ b/tests/where.json
@@ -37,11 +37,15 @@
     {
       "resourceType": "Observation",
       "id": "o1",
+      "status": "final",
+      "code": { "text": "code" },
       "valueInteger": 12
     },
     {
       "resourceType": "Observation",
       "id": "o2",
+      "status": "final",
+      "code": { "text": "code" },
       "valueInteger": 10
     }
   ],


### PR DESCRIPTION
Several test JSON files contain resources that fail FHIR R4 schema validation. These fixes add missing required fields and correct invalid values without changing test logic or expected results.

  - Missing required fields (cardinality 1..1)
    - **constant_types.json**: Add `Device.udiCarrier.deviceIdentifier` and `Device.udiCarrier.issuer` to d1, d2
    - **fn_boundary.json**: Add `Observation.status` to o4
    - **repeat.json**: Add `QuestionnaireResponse.status` and `QuestionnaireResponse.questionnaire` to qr1
    - **row_index.json**: Add `QuestionnaireResponse.status` and `QuestionnaireResponse.questionnaire` to qr1
    - **where.json**: Add `Observation.status` and `Observation.code` to o1, o2
    - **fn_reference_keys.json**: Add `Patient.link.type` to p1, p2
  - Invalid values
    - **fn_boundary.json**: Fix `valueTime` from `"12:34"` to `"12:34:00"` (FHIR time requires HH:MM:SS)
    - **fn_extension.json**: Remove empty `"extension": []` from Patient/pt3 (FHIR prohibits empty arrays)
  - Broken references
    - **constant_types.json**: Fix ClaimResponse/ImagingStudy references from `Patient/p1` (doesn't exist) to `Patient/pt1`
    - **fhirpath.json**: Add Organization/o1 referenced by Patient/pt1 via `managingOrganization`