### PR TITLE
Fix SQLQuery sql-must-be-sql-expressions for multi-content Libraries

### DIFF
--- a/input/fsh/profiles/library-profiles.fsh
+++ b/input/fsh/profiles/library-profiles.fsh
@@ -9,7 +9,7 @@ Context: Attachment
 Invariant: sql-must-be-sql-expressions
 Description: "The content of the Library must be SQL expressions."
 Severity: #error
-Expression: "content.contentType.startsWith('application/sql')"
+Expression: "content.all(contentType.startsWith('application/sql'))"
 
 Profile: SQLQuery
 Title: "SQL Query Library"

--- a/input/pagecontent/StructureDefinition-SQLQuery-intro.md
+++ b/input/pagecontent/StructureDefinition-SQLQuery-intro.md
@@ -81,16 +81,42 @@ For dialect-specific SQL, include separate attachments with a dialect parameter
 in `contentType` (e.g., `application/sql;dialect=postgresql`). Keep aliases and
 parameter names consistent across variants.
 
+A `contentType` of `application/sql` (with no `dialect` parameter) represents a
+default variant. It carries no dialect commitment and is intended to be broadly
+portable, so authors SHOULD restrict it to standard ANSI SQL constructs that
+work across the engines they expect to target. Implementations MAY treat the
+default variant as roughly equivalent to ANSI SQL when no dialect-specific
+variant matches.
+
+When a Library contains multiple `content` attachments, implementations choose
+which attachment to execute as follows:
+
+1. Prefer an attachment whose `contentType` declares a `dialect` parameter that
+   matches the executing engine (for example, an engine running PostgreSQL
+   selects `application/sql;dialect=postgresql`).
+2. If no matching dialect-specific attachment is present, fall back to the
+   default attachment with `contentType = "application/sql"`.
+3. If neither a matching dialect nor a default attachment is available,
+   implementations SHOULD return an error rather than guess at a translation
+   between dialects.
+
+Authors SHOULD include a default `application/sql` attachment whenever possible
+so that engines without a dedicated variant still have a portable fallback. All
+variants within a single Library SHALL be functionally equivalent: they SHALL
+expose the same parameters, reference the same table aliases, and produce the
+same logical result set.
+
 ### Conformance
 
 **Terminology:** `contentType` SHALL come from
 [All SQL Content Type Codes](ValueSet-AllSQLContentTypeCodes.html).
 
 **Constraints:**
-* Library type SHALL be `LibraryTypesCodes#sql-query`
-* `content.contentType` SHALL start with `application/sql`
-* `content.data` SHALL be present; the `sql-text` extension MAY carry a plain-text copy
-* Dependencies SHALL use `relatedArtifact` with `type = "depends-on"` and `label`
-* Parameters SHALL use `Library.parameter` with `use = "in"`
+
+- Library type SHALL be `LibraryTypesCodes#sql-query`
+- Every `content.contentType` SHALL start with `application/sql`
+- `content.data` SHALL be present; the `sql-text` extension MAY carry a plain-text copy
+- Dependencies SHALL use `relatedArtifact` with `type = "depends-on"` and `label`
+- Parameters SHALL use `Library.parameter` with `use = "in"`
 
 For examples and tooling guidance, see the Notes tab below.


### PR DESCRIPTION
## Problem

The [sql-must-be-sql-expressions](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/StructureDefinition-SQLQuery.html#constraints) invariant:

``` fhirpath
content.contentType.startsWith('application/sql')
```
Expression is invalid — `startsWith()` [signals an error when input contains multiple items](https://hl7.org/fhirpath/#startswithprefix-string-boolean). This profile allows multiple `content` entries

## Fix

```
content.all(contentType.startsWith('application/sql'))
```

[Reproduction in FHIRPath-Lab](https://fhirpath-lab.com/FhirPath?expression=content.contentType.startsWith%28%27application%2Fsql%27%29&engine=Aidbox%20%28Health%20Samurai%29&resourceJson=N4KABGBEBOCmDOB7ArtAxrAKgTwA60jAC4oAZASwCNoBDabSAGnCnIBNCTIBVAO3ICOyWAAUaAF3Kxe4gIJs2cePAQBFYfSYtIAW1jianMKAgRIuaIgBm5ADYFiYANotTpyAAtx43PCIB6f3gBWwBaRF5Qqw9yaAA6RGgAc39yFIBlcWhkNHFUWAARWBt%20SQj-dNVSdVhNVzAAXRYAX2YzVFsjT29fAKCQ8Mjo2ITk1JSKajpsfz5BYTFJaTkFJRV4Gs02qAA3WvhyCK6AJjiARjiABlCLAm3IXho9LrmhUQkpGXlFBHXNhnuknE9he-DeYEWn3EYG%20awQWjM8AMeXgXRouXIewRUHEeAcJBM7jQiDY5F4SSMLjcEEJ1Kg8GwSNgOi6Xh8fkCwTCESiMXiiRSaX8AGESbB0ozxMz-JNaPQcPh4KK2PDtnTIMSVV0uaE3nU6c16k0IK1tGwJPioMdLscAGyhS4AFlCx0dmEutqIZwArERjgBmADUl0uRBD2PMyEotnI8A8tS6lVIYAiYAAYgAJACSACUwAB1RIAazJSTAAHFLMhcBHiTJ0eJKfVae5Hs9HJAkyneOns3nC9AS%20SK1Wa2r3FL7MSWY4qXTjPV1QymTOuB1sfPdjRbMJWT0Of1uUM%20aMKYvTIa6caLywGvcAFaoWOkjFHWfN88akmlpubltLyVmT3Hw%20mQXgkQkeA4jA09-DA%20A2H8PRxA8El4CQx0AE4MMwuIvBZcd1U1S1IBDM4N3nSBSXgXBbBoBgOwHWwOHPE1z2vNiIDvbQ4DoqU2FkaBJCsBtf1Mf8cTxLoVXwXg2HgQYKLMOjKFgToO1wD5lgAfR2KQAHclKgJQUHQEi2V6QJYAADyeWjYFggA1AyihKcgyl4fxNKWGRdIMyB6lNNwJMgXF8Gk2BZPkxTCKgFS1K6byoW0mhVl%20PzYEM2KYAQUyMGAyz-Bsuz7CclzijJdzDk8pKdNSn5lAywzAtve5NNoZCE3fYLPzbEi0HcgFP2QFQujJIyqMQNBkD0esPK6YVBrAcREDAGxbClaAwHquFUWysKSKRaAfxarj7jrKUZDEmlPxsy6DjfEg5zpCS3EgdcOwsg8dR5YZ%20TGIVMmyXJ8lcyqPMPUIpWsxtYrenZt2EIGf0YrNMAzMBaF4ItYDYFK0uUBAYXSMAAAoAB0ezAdIAFFSBp4VMEptxat8vTMridhibAVnxG09hGGZ0xeaauI%20sFqmIBFnb0vZ-S4hlxqY14WAzgllmtN8xX4FFgbcXV4XNb57XRYgqUDalo38YanW5biXBEAg2xtOIi2eatk27erc1%20JS8Q3ZzAB5fNtIAOW4ABZAAhGmc1JgBKMBA8c2OyaFtwRFkHNMDRrNA9DsAo4ATXdny%20bt9h09MQOcwKVPi9L5LPYM6DcB93G-bAOv0mFRhG7qgnbZbk2ue74Uq8T2QSZNrGiyFtMg4j-u2YMoWAClA6zAvpcHpqq-z5fy5brmAF5D%20ttZRZFyuqfzDNY5p8%207YbTFYDAM%20smEKvZFDgpz%20bjmetsDv2IEAym8dKa03pozIW182AG3FkLE2ytVYGyAQbM2sADYOydi7MUlMF6ByXrPDu2sECUzvg-bau9Z4gPIqxMAl5qTcSIhES64gFQkRoLgWi5A0AfHKFyCaPtDAdkcpcWw3Ae5R2wEXfM3poAAC18w5isHInMRY0A6EcgALzQMcXRWYaZphzsKJIABpLMwoo6YBzNwayaZVBnFUJY4UsgkhZgzFHDwbByy2FsJQXgqi2A6H8WwbA3pcCKOsVHbg2Ao76SLgADRzFE%20RlwknHFsEWUgshEAeLcUkNA5Y0yXBoPmRyyA2Bpkwsccpjl-SkB0N6DwlB8zcCVOQdxViEnJNSco70GTjhpiLIojMa9bBoH9KHKwISwkRI8Io8sOZsCKKSaHHRmTrK4EoDoexuT8lWPccU0p9Sqk1MWcs1Z6zNn%20kUVEpJ00i5ZMuOKfSrjuleJ8X4gJQS1EqM0dovRZxan1MabwUOlw%20m2AOQU45JSykVPOZhS5Ky1kbKSXch501imYR0b4tM8BMmhx2Esjpi1unWMSSktJgzMkjLGRMqZMy5nMQiWcYpOZvmOSLPSy4sKjlJG4EWTCSSkmXG9I5TA3A15pm4GkXARjMIqMclmCxeS4UFKjqoVQjk15SMcjmNe7pHRJFUNkopCKznVNBRUxpoSiwUs1Uq9IOYaaOXSEYteijPHeN8f4wJqj1GAt0WgEFdS7WkF4I5fSSzSnKKDUk1QSQ3VStUNgfSlrTlIptai65GKsVrKeQCrRoaQVROsbHRyv8nVHMVcYnOJTRnjMmdMqwWi0zIBoPpQ5NNFHpHdJcLNiLKk2ojQ0p16QRXGvIL0mlAyhkMpbcy2ZoTmI9s1Sa4d1qanjvtdkrMBQh0nJHcivN6Lbn3KLTkK1OaalRI1VmNMbBcx6rTL675Aa-msvCS0ou-pUkhO4EkEQ6Qo6XDQNG2wtaYmYCLMmk9O6UVLLRTczFV7HnIGebYV56RZCYUPbge8NAUnekWkWcx3BLiOQjnY8OTrEN3swhW95PSsP5jODCx9TbGWtpmZQPxyBFGYBpp09x2HcOsesfihF-apMJMoNMqF%20ZrJqOOJhUZqhcDlmFZhUOni16tJ0MCRRFyUP5p0WsiO5jxEeDlUWYDwbS3AswrI%20R0BD1DojqoE%20J8ApuCCuJW6MNpAPV4Ndakr13AfS4F9PoP1jwjAFOMCon8QZwDBqUaqkNoawwYWYBGO5xRZBRlwKBDNMBdyzAOrejMk4F1JiLCubAIFUya8fNg3M4HYKtnbRBbWPa72frvFBatYGDZtrrQaPWy4X1li3TBM2m5DZbjggwztiIEMXk-VevAN5b3-itzKQsD7tY5qfQ7k27ZwIoffN1O2OYvz2CAz%20sAhY-z-jvK7LcgEgKIGA3gNc655gbmd%20WAtLuXy9m3C0eMJBdxpj3PuX2ofD13qPRHwp-PziYW4Fh1IvwyGWJwtEPCYz8IhlyAA3KSbcsBcgnzW0kJQIRhESFEVwKjNG6PcCMUa7gZwjVwfDkqzewoPDUv6ek9D2Ku35i0wx29o7d1gqaQehtH7-W-NUeU1QYnt1Mb3U0lpbTyVdIN8r5DVyL0y%20vU5oFYbMLwHKd6WwEd0jycl7SxdzamVtp-RE4jpGBVfK14G-5GjnOO6NxCqFKSuOHNDz88P9uy22oaVGqOOwplcsoDU%208lBjg5mg6MgdIYLfIr3cKIsuBQPcFNYxy3560OFsea4qOIhMCzq9wu23mHdcgbAz36Xwzfd8dXfM70w%206VZMdcxV9srNfJ%20-Wu39Hh-2Ab2YP8DkHHLQfN6obg3oaZL6-UGktDvw2q50KHNuGYiyD9kLaCTsAtMiGFTmOVs7hT5iH3073fe00uu8Ap%202uEeIaLmMeMacalwCaaiSaKa7qmA6amajeZ65mNurexakel%20zG0SMcOY1aBQ2OnEjQIAzQQAA&terminologyserver=https%3A%2F%2Fsqlonfhir-r4.azurewebsites.net%2Ffhir) using the [Unique Patient Addresses](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/Library-UniquePatientAddressesQuery.json.html) example