### PR TITLE
Spike: multi-version IG

### DIFF
--- a/input/fsh/models.fsh
+++ b/input/fsh/models.fsh
@@ -20,12 +20,36 @@ Expression: "(forEach.exists().toInteger() + forEachOrNull.exists().toInteger() 
 // NOTE: Using RuleSet with LogicalModels where you pass parameters seems to be broken
 Logical: ViewDefinition
 Title: "View Definition"
-Parent: CanonicalResource
+Parent: DomainResource
 Description: """
-A ViewDefinition represents a tabular projection of a FHIR resource, where the columns and inclusion 
-criteria are defined by FHIRPath expressions. 
+A ViewDefinition represents a tabular projection of a FHIR resource, where the columns and inclusion
+criteria are defined by FHIRPath expressions.
 """
+// Canonical resource metadata. ViewDefinition was previously parented on
+// CanonicalResource to inherit these fields, but CanonicalResource is only
+// defined as an abstract type from R5 onward. Defining the fields directly
+// keeps the on-wire shape consistent with other canonical resources while
+// allowing the IG publisher to emit version-specific packages back to R4.
+* url 0..1 uri "Canonical identifier for this view definition" """
+  An absolute URI that is used to identify this view definition when it is referenced in a specification,
+  model, design or an instance; also called its canonical identifier.
+"""
+* identifier 0..* Identifier "Additional identifier for the view definition"
+* version 0..1 string "Business version of the view definition"
+* name 0..1 string "Name for this view definition (machine friendly)"
 * name obeys sql-name
+* title 0..1 string "Name for this view definition (human friendly)"
+* status 1..1 code "draft | active | retired | unknown"
+* status from http://hl7.org/fhir/ValueSet/publication-status (required)
+* experimental 0..1 boolean "For testing purposes, not real usage"
+* date 0..1 dateTime "Date last changed"
+* publisher 0..1 string "Name of the publisher/steward (organization or individual)"
+* contact 0..* ContactDetail "Contact details for the publisher"
+* description 0..1 markdown "Natural language description of the view definition"
+* useContext 0..* UsageContext "The context that the content is intended to support"
+* jurisdiction 0..* CodeableConcept "Intended jurisdiction for view definition (if applicable)"
+* purpose 0..1 markdown "Why this view definition is defined"
+* copyright 0..1 markdown "Use and/or publishing restrictions"
 * resource 1..1 code "FHIR resource for the ViewDefinition" """
   The FHIR resource that the view is based upon, e.g. 'Patient' or 'Observation'.
 """

--- a/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
+++ b/input/pagecontent/StructureDefinition-ViewDefinition-notes.md
@@ -89,7 +89,7 @@ For instance, each Patient resource can have multiple addresses, which users can
 expand into a separate `patient_addresses` table with one row per address. Each
 row would still have a `patient_id` field to know which patient that address row
 is associated with. You can see this in
-the [PatientAddresses example](Binary-PatientAddresses.html), which unrolls
+the [PatientAddresses example](ViewDefinition-PatientAddresses.html), which unrolls
 addresses as described above.
 
 [forEach](StructureDefinition-ViewDefinition-definitions.html#diff_ViewDefinition.select.forEach)
@@ -319,7 +319,7 @@ produce the same columns including their specified names and FHIR types.
 The above example uses `forEach` to select different data elements from the
 resources to be included in the union. For other use cases, it is possible to
 define the columns directly in the `select`. See
-the [PatientAndContactAddressUnion example](Binary-PatientAndContactAddressUnion.html)
+the [PatientAndContactAddressUnion example](ViewDefinition-PatientAndContactAddressUnion.html)
 for a complete version of the above.
 
 The columns produced from the `unionAll` list are effectively added to the

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -52,6 +52,17 @@ dependencies:
 parameters:
   excludettl: true
   path-test: tests
+  # Promote the ViewDefinition logical model to a published resource type so
+  # FHIR servers can store and serve view definitions through the standard
+  # REST API. The IG publisher auto-promotes kind=logical to kind=resource
+  # when a StructureDefinition is loaded as a custom resource. This IG is
+  # listed in https://fhir.github.io/ig-registry/igs-approved-for-custom-resource.json.
+  custom-resource: fsh-generated/resources/StructureDefinition-ViewDefinition.json
+  # Emit a sibling R4 package (org.sql-on-fhir.ig.r4.tgz) alongside the
+  # primary R5 package, so R4-based servers can load the IG without
+  # rewriting its dependencies. The publisher rewrites *.r5 dependencies to
+  # *.r4 in the variant package.
+  generate-version: r4
 
 #   validation: [allow-any-extensions, no-broken-links]
 #


### PR DESCRIPTION
A spike against #335 exploring whether the SQL on FHIR IG can publish ViewDefinition as a real FHIR resource type rather than a logical model, and whether multi-version packages can ship for R4 alongside the primary R5 build.

The diff in this PR is small (3 files, +40/-5) and produces R5, R4, and combined `.tgz` packages out of the box. It is offered as a starting point for working group discussion. The broader exploration that produced this commit also surfaced a number of IG publisher gaps the WG may want to be aware of before committing to this direction; those findings are below.

## Changes

`input/fsh/models.fsh`: re-parents `ViewDefinition` from `CanonicalResource` to `DomainResource` so the IG publisher can convert it back to R4 (R4 has no `CanonicalResource` abstract type). The canonical-resource metadata fields (`url`, `identifier`, `version`, `name`, `title`, `status`, `experimental`, `date`, `publisher`, `contact`, `description`, `useContext`, `jurisdiction`, `purpose`, `copyright`) are declared directly on the resource so the on-wire shape is unchanged.

`sushi-config.yaml`: adds two IG parameters.
`custom-resource: fsh-generated/resources/StructureDefinition-ViewDefinition.json` tells the publisher to promote `kind=logical` to `kind=resource` and register `ViewDefinition` as a custom resource type. This IG is on the approved list at https://fhir.github.io/ig-registry/igs-approved-for-custom-resource.json. The published package now contains a `kind=resource` SD plus 11 example instances at `package/custom/ViewDefinition-*.json` rather than the previous `Binary-*.json` placeholders.
`generate-version: r4` makes the publisher emit a sibling `org.sql-on-fhir.ig.r4.tgz` with `*.r5` dependencies rewritten to `*.r4` (`hl7.fhir.uv.extensions.r4`, `hl7.terminology.r4`, etc).

`input/pagecontent/StructureDefinition-ViewDefinition-notes.md`: updates two `Binary-*` example links to `ViewDefinition-*` since the publisher renames example files when the resource type is promoted.

## Build outcome

`Errors: 38, Warnings: 66, Info: 54, Broken Links: 17`. Three packages produced under `output/`: `package.tgz` (R5, 144 KB), `org.sql-on-fhir.ig.r4.tgz` (R4 sibling, 159 KB), `package-combined.tgz` (89 KB). The errors and broken links are mostly pre-existing markdown / anchor issues unrelated to this change.

## Findings worth flagging to the WG

The semantically correct flag for this is actually `additional-resource`, not `custom-resource`. The FHIR Tools IG describes the difference as: `custom-resource` is a type the IG _uses_ but does not publish; `additional-resource` is a type the IG _publishes_ for others to consume. `additional-resource` sets the `http://hl7.org/fhir/tools/StructureDefinition/additional-resource` extension on the SD, which downstream tooling can use to discover \"new resource types this IG introduces\". `custom-resource` does not.

We tried switching to `additional-resource` and ran into several integration gaps in the IG publisher (master, 2.2.7 release):

The handler only accepts XML files. SUSHI only emits JSON. Workaround requires a post-SUSHI conversion step in the build script.

Every `additional-resource` requires a `bundle-<TypeName>-search-params.xml` alongside it (`PublisherIGLoader#loadSearchBundle`). For new resource types with no search parameters yet, this has to be a hand-written empty Bundle stub.

The renderer at `StructureDefinitionRenderer#scanForKeyElements` hard-codes `http://hl7.org/fhir/StructureDefinition/<typeTail>` when looking up an element's base type. For SDs whose URL is in the IG canonical namespace, this lookup returns null and rendering profiles of the resource type crashes with a NullPointerException. This is recoverable by giving the SD a URL in the core FHIR namespace (`http://hl7.org/fhir/StructureDefinition/ViewDefinition`) and adding `special-url-base: http://hl7.org/fhir`, which is the pattern HL7/data-access-policies, HL7/admin-incubator, and HL7/immunization-incubator use.

When a hand-written XML SD is placed in `input/resources/<typename>/` (the documented location, where SUSHI uses it as a predefined resource for compiling profiles and instances), the publisher's `additional-resource` handler caches it at `PublisherIGLoader.java:1043` _and_ the auto-loader caches it again at `loadConformance1`/`cacheResourceFromPackage` (line 4252) with package version metadata applied. This produces \"Ambiguous type ViewDefinition\" at output-generation time. We could not reproduce this against an `fhirVersion: 6.0.0-ballot3` IG using the same setup as the working IGs above; switching this IG to R6 produced a clean build (9 broken links, all pre-existing markdown anchors), with the SD properly published carrying the `additional-resource: true` extension. We did not isolate exactly what the version-difference depends on.

We also looked at whether IGs can supply cross-version maps (StructureMap) for instances of their custom resource types, so a single IG could ship usable R5 and R4 sibling packages. The publisher's `generate-version` only auto-converts core FHIR types via hard-coded version converters (`VersionConvertorFactory_X_Y.convertResource`); it has no hook for IG-supplied conversion maps, and the `OtherVersions` slot on `FetchedResource` is only populated for `StructureDefinition` and `SearchParameter` (`PublisherProcessor#generateOtherVersions`). Without an upstream change there is currently no way to ship working R4/R5 sibling packages that include the ViewDefinition type and its instances.

Refs #335.