### PR TITLE
Make SQLQuery contentType binding extensible

### DIFF
--- a/input/fsh/profiles/library-profiles.fsh
+++ b/input/fsh/profiles/library-profiles.fsh
@@ -26,7 +26,10 @@ versioning.
 * content 1..* MS
 * content.contentType 1..1 MS
 * content.contentType ^short = "application/sql or application/sql;dialect=..."
-* content.contentType from AllSQLContentTypeCodes (required)
+* content.contentType from http://hl7.org/fhir/ValueSet/mimetypes (required)
+* content.contentType ^binding.additional[+].purpose = #extensible
+* content.contentType ^binding.additional[=].valueSet = Canonical(AllSQLContentTypeCodes)
+* content.contentType ^binding.additional[=].documentation = "SQLQuery content types, including dialect-specific variants. Authors SHOULD use a code from this value set when one applies; codes outside this value set MAY be used for SQL dialects not yet enumerated, subject to the sql-must-be-sql-expressions invariant."
 * content.extension contains sql-text named sqlText 0..1 MS
 * content.extension[sqlText] ^short = "Plain-text SQL for readability"
 * content.data 1..1 MS

--- a/input/pagecontent/StructureDefinition-SQLQuery-intro.md
+++ b/input/pagecontent/StructureDefinition-SQLQuery-intro.md
@@ -108,8 +108,11 @@ same logical result set.
 
 ### Conformance
 
-**Terminology:** `contentType` SHALL come from
-[All SQL Content Type Codes](ValueSet-AllSQLContentTypeCodes.html).
+**Terminology:** `contentType` SHOULD come from
+[All SQL Content Type Codes](ValueSet-AllSQLContentTypeCodes.html). The binding
+is extensible: when one of these codes covers the dialect, that code SHALL be
+used; otherwise, an alternative code MAY be supplied (subject to the constraint
+that every `contentType` starts with `application/sql`).
 
 **Constraints:**
 


### PR DESCRIPTION
Closes #351.

FHIR forbids weakening a parent's required binding to extensible (`Attachment.contentType` is required to `MimeTypes` in core), so this uses `ElementDefinition.binding.additional` to layer an extensible binding to `AllSQLContentTypeCodes` alongside the inherited required binding. The `sql-must-be-sql-expressions` invariant continues to enforce the `application/sql` prefix.

The FSH restates the inherited required binding so SUSHI produces a clean differential; otherwise the inherited `binding-definition` extension (with `valueString` where the current tools extension requires `valueMarkdown`) is materialised and trips the publisher.

Validation: SUSHI clean, IG Publisher build clean (`Errors: 0`, matching the pre-edit baseline). Rendered SD page shows an \"Additional Bindings\" table linking to the value set with purpose `Extensible`. All existing examples and `sof-js` fixtures use codes already in the value set, so no example updates were needed.