### PR TITLE
Fix SQLQuery relatedArtifact.type to depends-on

### DIFF
--- a/input/fsh/profiles/library-profiles.fsh
+++ b/input/fsh/profiles/library-profiles.fsh
@@ -35,6 +35,7 @@ versioning.
 // ViewDefinition dependencies
 * relatedArtifact MS
 * relatedArtifact.type 1..1 MS
+* relatedArtifact.type = #depends-on
 * relatedArtifact.type ^short = "depends-on for ViewDefinition references"
 * relatedArtifact.resource 1..1 MS
 * relatedArtifact.resource ^short = "Canonical URL of ViewDefinition"


### PR DESCRIPTION
Adds a fixed value of `depends-on` for `relatedArtifact.type` on the SQLQuery profile, since dependencies on ViewDefinitions are always `depends-on` references.

Closes #352