### PR TITLE
Reconcile cross-operation spec inconsistencies (#358–#363)

### DIFF
--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -332,8 +332,8 @@ Description: "Execute a view definition against supplied or server data."
 * parameter[10].use = #out
 * parameter[10].min = 1
 * parameter[10].max = "1"
-* parameter[10].type = #Resource
-* parameter[10].documentation = "Transformed data in the requested output format. Returns Binary for the flat formats (csv, json, ndjson, parquet) or Parameters for _format=fhir. The Binary denotes a raw binary stream in the format's native media type, not a serialized Binary resource envelope; see Common Operation Behavior (operations-common.html)."
+* parameter[10].type = #Binary
+* parameter[10].documentation = "Transformed data in the requested output format, returned as a raw binary stream in the format's native media type, not a serialized Binary resource envelope. When _format=fhir is requested, the response is a Parameters resource instead. See Common Operation Behavior (operations-common.html)."
 
 Instance: SQLQueryRun
 Usage: #definition
@@ -430,8 +430,8 @@ Description: "Execute a SQLQuery Library against ViewDefinition tables."
 * parameter[7].use = #out
 * parameter[7].min = 1
 * parameter[7].max = "1"
-* parameter[7].type = #Resource
-* parameter[7].documentation = "Query results in the requested output format. Returns Binary for the flat formats (csv, json, ndjson, parquet) or Parameters for _format=fhir. The Binary denotes a raw binary stream in the format's native media type, not a serialized Binary resource envelope; see Common Operation Behavior (operations-common.html)."
+* parameter[7].type = #Binary
+* parameter[7].documentation = "Query results in the requested output format, returned as a raw binary stream in the format's native media type, not a serialized Binary resource envelope. When _format=fhir is requested, the response is a Parameters resource instead. See Common Operation Behavior (operations-common.html)."
 
 Instance: SQLQueryExport
 Usage: #definition

--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -64,7 +64,7 @@ Description: "Export a view definition. User can provide view definition referen
 * parameter[2].type = #code
 * parameter[2].binding.strength = #extensible
 * parameter[2].binding.valueSet = Canonical(OutputFormatCodes)
-* parameter[2].documentation = "Bulk export output format (for example csv, ndjson, parquet, json). Optional; if omitted, the server returns ndjson by default."
+* parameter[2].documentation = "Bulk export output format (csv, ndjson, parquet, json, fhir). Use fhir to export each output as newline-delimited FHIR Parameters rows. Optional; if omitted, the server returns ndjson by default. See Common Operation Behavior (operations-common.html)."
 
 * parameter[3].name = #header
 * parameter[3].use = #in
@@ -235,7 +235,7 @@ Description: "Execute a view definition against supplied or server data."
 * parameter[0].type = #code
 * parameter[0].binding.strength = #extensible
 * parameter[0].binding.valueSet = Canonical(OutputFormatCodes)
-* parameter[0].documentation = "Output format for the result (for example json, ndjson, csv, parquet). Optional; if omitted, the server returns ndjson by default."
+* parameter[0].documentation = "Output format for the result (json, ndjson, csv, parquet, fhir). Use fhir to return results as a FHIR Parameters resource. Optional; if omitted, the server returns ndjson by default. See Common Operation Behavior (operations-common.html)."
 
 * parameter[1].name = #header
 * parameter[1].use = #in
@@ -305,7 +305,7 @@ Description: "Execute a view definition against supplied or server data."
 * parameter[7].scope[1] = #type
 * parameter[7].scope[2] = #instance
 * parameter[7].type = #Resource
-* parameter[7].documentation = "FHIR resources to transform instead of using server data."
+* parameter[7].documentation = "FHIR resources to transform instead of using server data. Repeatable. A Bundle supplied here is unwrapped: the ViewDefinition runs against each Bundle.entry[*].resource rather than against the Bundle itself. See OperationDefinition-ViewDefinitionRun notes (Resource Parameter and Bundle Inputs)."
 
 * parameter[8].name = #_limit
 * parameter[8].use = #in
@@ -332,8 +332,8 @@ Description: "Execute a view definition against supplied or server data."
 * parameter[10].use = #out
 * parameter[10].min = 1
 * parameter[10].max = "1"
-* parameter[10].type = #Binary
-* parameter[10].documentation = "Transformed data encoded in the requested output format."
+* parameter[10].type = #Resource
+* parameter[10].documentation = "Transformed data in the requested output format. Returns Binary for the flat formats (csv, json, ndjson, parquet) or Parameters for _format=fhir. The Binary denotes a raw binary stream in the format's native media type, not a serialized Binary resource envelope; see Common Operation Behavior (operations-common.html)."
 
 Instance: SQLQueryRun
 Usage: #definition
@@ -364,8 +364,8 @@ Description: "Execute a SQLQuery Library against ViewDefinition tables."
 * parameter[0].scope[2] = #instance
 * parameter[0].type = #code
 * parameter[0].binding.strength = #extensible
-* parameter[0].binding.valueSet = Canonical(SQLQueryRunOutputFormatCodes)
-* parameter[0].documentation = "Output format for the result (json, ndjson, csv, parquet, fhir). Use fhir to return results as a FHIR Parameters resource. Optional; if omitted, the server returns ndjson by default."
+* parameter[0].binding.valueSet = Canonical(OutputFormatCodes)
+* parameter[0].documentation = "Output format for the result (json, ndjson, csv, parquet, fhir). Use fhir to return results as a FHIR Parameters resource. Optional; if omitted, the server returns ndjson by default. See Common Operation Behavior (operations-common.html)."
 
 * parameter[1].name = #header
 * parameter[1].use = #in
@@ -531,7 +531,7 @@ Description: "Export SQLQuery Library results asynchronously using the FHIR Asyn
 * parameter[3].type = #code
 * parameter[3].binding.strength = #extensible
 * parameter[3].binding.valueSet = Canonical(OutputFormatCodes)
-* parameter[3].documentation = "Output format for the exported files (csv, ndjson, parquet, json)."
+* parameter[3].documentation = "Output format for the exported files (csv, ndjson, parquet, json, fhir). Use fhir to export each output as newline-delimited FHIR Parameters rows. See Common Operation Behavior (operations-common.html)."
 
 * parameter[4].name = #header
 * parameter[4].use = #in

--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -437,7 +437,7 @@ Instance: SQLQueryExport
 Usage: #definition
 InstanceOf: OperationDefinition
 Title: "SQLQuery Export"
-Description: "Export SQLQuery Library results asynchronously using the FHIR Asynchronous Interaction Request Pattern."
+Description: "Export SQLQuery Library results asynchronously using the FHIR Asynchronous Bulk Data Request Pattern."
 
 * id = "SQLQueryExport"
 * url = "http://sql-on-fhir.org/OperationDefinition/$sqlquery-export"

--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -63,8 +63,8 @@ Description: "Export a view definition. User can provide view definition referen
 * parameter[2].scope[1] = #type
 * parameter[2].type = #code
 * parameter[2].binding.strength = #extensible
-* parameter[2].binding.valueSet = Canonical(OutputFormatCodes)
-* parameter[2].documentation = "Bulk export output format (csv, ndjson, parquet, json, fhir). Use fhir to export each output as newline-delimited FHIR Parameters rows. Optional; if omitted, the server returns ndjson by default. See Common Operation Behavior (operations-common.html)."
+* parameter[2].binding.valueSet = Canonical(ExportOutputFormatCodes)
+* parameter[2].documentation = "Bulk export output format (csv, ndjson, parquet, json). Optional; if omitted, the server returns ndjson by default. See Common Operation Behavior (operations-common.html)."
 
 * parameter[3].name = #header
 * parameter[3].use = #in
@@ -530,8 +530,8 @@ Description: "Export SQLQuery Library results asynchronously using the FHIR Asyn
 * parameter[3].scope[1] = #type
 * parameter[3].type = #code
 * parameter[3].binding.strength = #extensible
-* parameter[3].binding.valueSet = Canonical(OutputFormatCodes)
-* parameter[3].documentation = "Output format for the exported files (csv, ndjson, parquet, json, fhir). Use fhir to export each output as newline-delimited FHIR Parameters rows. See Common Operation Behavior (operations-common.html)."
+* parameter[3].binding.valueSet = Canonical(ExportOutputFormatCodes)
+* parameter[3].documentation = "Output format for the exported files (csv, ndjson, parquet, json). See Common Operation Behavior (operations-common.html)."
 
 * parameter[4].name = #header
 * parameter[4].use = #in

--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -431,7 +431,7 @@ Description: "Execute a SQLQuery Library against ViewDefinition tables."
 * parameter[7].min = 1
 * parameter[7].max = "1"
 * parameter[7].type = #Resource
-* parameter[7].documentation = "Query results. Returns Binary for flat formats (csv, json, ndjson, parquet) or Parameters for _format=fhir."
+* parameter[7].documentation = "Query results in the requested output format. Returns Binary for the flat formats (csv, json, ndjson, parquet) or Parameters for _format=fhir. The Binary denotes a raw binary stream in the format's native media type, not a serialized Binary resource envelope; see Common Operation Behavior (operations-common.html)."
 
 Instance: SQLQueryExport
 Usage: #definition

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -72,16 +72,6 @@ Description: "Output format codes for SQL on FHIR."
 
 ValueSet: OutputFormatCodes
 Title: "Output Format Codes"
-Description: "ValueSet of all codes from Output Format Codes codesystem"
+Description: "ValueSet of all codes from Output Format Codes codesystem. Shared by all four SQL on FHIR data operations; see Common Operation Behavior."
 * ^experimental = false
 * codes from system OutputFormatCodes
-
-ValueSet: SQLQueryRunOutputFormatCodes
-Title: "SQLQuery Run Output Format Codes"
-Description: "Output format codes supported by the $sqlquery-run operation."
-* ^experimental = false
-* OutputFormatCodes#csv
-* OutputFormatCodes#ndjson
-* OutputFormatCodes#parquet
-* OutputFormatCodes#json
-* OutputFormatCodes#fhir

--- a/input/fsh/terminology.fsh
+++ b/input/fsh/terminology.fsh
@@ -72,6 +72,15 @@ Description: "Output format codes for SQL on FHIR."
 
 ValueSet: OutputFormatCodes
 Title: "Output Format Codes"
-Description: "ValueSet of all codes from Output Format Codes codesystem. Shared by all four SQL on FHIR data operations; see Common Operation Behavior."
+Description: "ValueSet of all codes from Output Format Codes codesystem. Used by the synchronous run operations; see Common Operation Behavior."
 * ^experimental = false
 * codes from system OutputFormatCodes
+
+ValueSet: ExportOutputFormatCodes
+Title: "Export Output Format Codes"
+Description: "Output format codes supported by the export operations. Excludes fhir, which applies to the run operations only; see Common Operation Behavior."
+* ^experimental = false
+* OutputFormatCodes#csv
+* OutputFormatCodes#ndjson
+* OutputFormatCodes#parquet
+* OutputFormatCodes#json

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
@@ -19,9 +19,8 @@ Export SQLQuery Library results asynchronously using the FHIR Asynchronous Inter
 
 1. Client sends request with `Prefer: respond-async` header
 2. Server returns `202 Accepted` with `Content-Location` polling URL
-3. Client polls for status until `303 See Other` redirect
-4. Client retrieves results from redirect location
-5. Client downloads exported files from `output.location` URLs
+3. Client polls for status until the poll returns `200 OK` with the manifest in the body
+4. Client downloads exported files from the `output.location` URLs in the manifest
 
 This operation combines the query source and parameter binding from
 [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) with the asynchronous

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
@@ -1,4 +1,4 @@
-Export SQLQuery Library results asynchronously using the FHIR Asynchronous Interaction Request Pattern.
+Export SQLQuery Library results asynchronously using the FHIR Asynchronous Bulk Data Request Pattern.
 
 **Use Cases:**
 

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -474,25 +474,25 @@ Content-Type: application/fhir+json
    error status code (e.g. `500 Internal Server Error`) with an
    `OperationOutcome` body. Polling-transport errors and operation failures are
    distinguished by the status code on the poll response itself.
-7. **Cancellation** (Recommended):
+6. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
     - Client sends `DELETE` request to the status polling URL
     - Server responds with `202 Accepted`
     - Subsequent status requests return `404 Not Found`
     - Server SHOULD clean up any partial results
-8. **Result Lifetime**:
+7. **Result Lifetime**:
    The completed status URL (which returns the manifest) and the
    `output.location` download URLs SHALL remain valid for at least 24 hours after
    export completion:
     - Servers SHOULD support multiple retrievals of the completed manifest
     - Servers MAY include an `Expires` header to indicate when the URLs expire
     - Clients should retrieve results promptly but can retry within the validity window
-9. **Access Control**:
+8. **Access Control**:
    Servers SHALL protect status and download URLs with appropriate access controls:
     - Same authorization context as the original request, OR
     - Non-guessable URLs (e.g., cryptographically random tokens)
     - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
-10. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
+9. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
 
 #### Examples
 

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -4,7 +4,7 @@
 
 #### Asynchronous Pattern
 
-This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
+This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and query source parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
@@ -13,13 +13,13 @@ This operation follows the [FHIR Asynchronous Interaction Request Pattern](https
 5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
 6. Client downloads the exported files from the `output.location` URLs in the manifest
 
-**Note**: This operation uses Parameters resource format instead of Bundle format to:
+**Note**: This operation uses a FHIR `Parameters` resource as the manifest instead of the Bulk Data JSON manifest object to:
 
 - Provide structured status reporting and metadata
 - Allow extensible output metadata specific to export operations
 - Maintain consistency with other FHIR operations
 
-**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Interaction Request Pattern (and the Bulk Data pattern it generalises). The operation does not use a `303 See Other` redirect to a separate result resource, so standard async/Bulk Data clients interoperate without special handling.
+**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Bulk Data Request Pattern. The operation does not use a `303 See Other` redirect to a separate result resource, so standard Bulk Data clients interoperate without special handling.
 
 ##### Async Flow Diagram
 

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -149,11 +149,11 @@ Provides ViewDefinitions that serve as table sources for the SQL queries. These 
 
 ##### Export Control
 
-| Name             | Type    | Min | Max | Description                                                                                   |
-| ---------------- | ------- | --- | --- | --------------------------------------------------------------------------------------------- |
-| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                          |
-| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`. [Details](#format-parameter-clarification) |
-| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                 |
+| Name             | Type    | Min | Max | Description                                                                                           |
+| ---------------- | ------- | --- | --- | ----------------------------------------------------------------------------------------------------- |
+| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
+| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
+| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                         |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -891,7 +891,7 @@ Prefer: respond-async
         {
           "name": "viewReference",
           "valueReference": {
-            "reference": "Binary/UsCoreBloodPressures"
+            "reference": "ViewDefinition/UsCoreBloodPressures"
           }
         }
       ]

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -4,14 +4,14 @@
 
 #### Asynchronous Pattern
 
-This operation follows the FHIR Asynchronous Interaction Request Pattern:
+This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and query source parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
 3. Client polls the status URL for export progress
 4. Server responds with `202 Accepted` while export is in progress (MAY include interim results)
-5. Upon completion, server returns `303 See Other` with `Location` header pointing to result URL
-6. Client GETs the result URL to retrieve final output (identical to synchronous response format)
+5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
+6. Client downloads the exported files from the `output.location` URLs in the manifest
 
 **Note**: This operation uses Parameters resource format instead of Bundle format to:
 
@@ -19,7 +19,7 @@ This operation follows the FHIR Asynchronous Interaction Request Pattern:
 - Allow extensible output metadata specific to export operations
 - Maintain consistency with other FHIR operations
 
-**Note**: The `303 See Other` redirect pattern cleanly separates status polling from result retrieval, eliminating ambiguity around error handling and request header scope.
+**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Interaction Request Pattern (and the Bulk Data pattern it generalises). The operation does not use a `303 See Other` redirect to a separate result resource, so standard async/Bulk Data clients interoperate without special handling.
 
 ##### Async Flow Diagram
 
@@ -43,17 +43,11 @@ sequenceDiagram
     rect rgb(240, 255, 240)
     Note over C,S: Step 3: Completion
     C->>S: GET /status/abc123
-    S-->>C: 303 See Other<br/>Location: /result/abc123
-    end
-
-    rect rgb(255, 255, 240)
-    Note over C,S: Step 4: Result
-    C->>S: GET /result/abc123
-    S-->>C: 200 OK<br/>Body: Parameters{output: [{name, location}]}
+    S-->>C: 200 OK<br/>Body: Parameters{status: completed, output: [{name, location}]}
     end
 
     rect rgb(255, 248, 240)
-    Note over C,S: Step 5: Download
+    Note over C,S: Step 4: Download
     C->>S: GET /export/abc123/bp-results.csv
     S-->>C: 200 OK<br/>Content-Type: text/csv<br/>Body: patient_id,systolic,...
     end
@@ -80,8 +74,6 @@ sequenceDiagram
     participant S as Server
 
     C->>S: GET /status/abc123
-    S-->>C: 303 See Other<br/>Location: /result/abc123
-    C->>S: GET /result/abc123
     S-->>C: 500 Internal Server Error<br/>Body: OperationOutcome{severity: error, diagnostics: ...}
 ```
 
@@ -109,19 +101,16 @@ Optional filtering parameters:
 
 ##### Status Request
 
-- `Accept` (recommended) - Specifies the format of the status response
-
-##### Result Request
-
-- `Accept` (recommended) - Specifies the format of the final result response
+- `Accept` (recommended) - Specifies the format of the status response, including the completion (`200 OK`) response that carries the manifest
 
 ##### Header Scope
 
-Request headers sent during status polling apply **only to the status response**, not to the final operation result. This separation:
-
-- Allows different content negotiation for status vs. result responses
-- Enables servers to use different formats for interim status (e.g., minimal JSON) vs. final results (e.g., detailed Parameters)
-- Eliminates ambiguity about which response the headers apply to
+Each status-poll request's headers apply to **that poll's response**. Because
+completion is delivered as `200 OK` with the manifest in the body of the
+status-poll response (there is no separate result resource), the `Accept` header
+sent on the completing poll governs the representation of the manifest. This
+allows a client to negotiate a different representation for interim status
+responses (e.g. minimal JSON) than for the final manifest if it chooses.
 
 #### Parameters
 
@@ -203,8 +192,19 @@ Servers SHALL document which reference formats they support in their CapabilityS
 
 ##### Format Parameter Clarification
 
-It is RECOMMENDED to support 'json', 'ndjson' and 'csv' formats by default.
-Servers may support other formats, but they should be explicitly documented in the CapabilityStatement.
+The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`) and the
+default are defined in
+[Common Operation Behavior](operations-common.html#output-formats) and apply to
+this operation:
+
+- It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
+  support `parquet` and `fhir`, and SHALL document supported formats in the
+  CapabilityStatement.
+- If `_format` is omitted, the server SHALL produce the export output in `ndjson`
+  format.
+- `_format=fhir` exports each output as a file of newline-delimited FHIR
+  `Parameters` rows (media type `application/fhir+ndjson`); see
+  [FHIR Format](operations-common.html#fhir-format).
 
 ##### Patient Parameter Clarification
 
@@ -244,7 +244,9 @@ SQLQuery profile for the binding rules and the mapping from
 
 #### Output Parameters
 
-Output parameters appear in the **result response** (after following the `303 See Other` redirect), not in status polling responses.
+Output parameters appear in the **completion response** — the `200 OK`
+status-poll response that carries the manifest. They are not present in the
+`202 Accepted` responses returned while the export is still in progress.
 
 ##### Export Identifiers
 
@@ -340,11 +342,11 @@ The $sqlquery-export operation uses standard HTTP status codes to indicate the o
 | Status Code               | Description          | When to Use                                                          |
 | ------------------------- | -------------------- | -------------------------------------------------------------------- |
 | 202 Accepted              | In Progress          | Export request accepted or still in progress during polling          |
-| 303 See Other             | Complete             | Export complete, follow `Location` header to retrieve results        |
+| 200 OK                    | Complete             | Export complete; the status-poll response body carries the manifest  |
 | 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers |
 | 404 Not Found             | Not Found            | SQLQuery Library not found, or cancelled export status URL           |
 | 422 Unprocessable Entity  | Business Logic Error | Valid request but query is invalid or cannot be executed             |
-| 500 Internal Server Error | Server Error         | Unexpected server error (at result URL indicates operation failure)  |
+| 500 Internal Server Error | Server Error         | Unexpected server error; on a status poll, indicates operation failure |
 
 {:.table-data}
 
@@ -465,31 +467,31 @@ Content-Type: application/fhir+json
     - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
     - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
     - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
-4. **Completion**: When export is ready, server responds with:
-    - `303 See Other` status code
-    - `Location` header pointing to the result URL
-    - Response body is optional (MAY be empty or contain minimal status)
-5. **Result Retrieval**: Client GETs the result URL from the `Location` header:
-    - `200 OK` status code with Parameters resource containing `output` locations
-    - Response format is identical to what a synchronous call would return
-6. **Error Handling**: If export fails:
-    - Status endpoint still returns `303 See Other` with `Location` header
-    - Result URL returns appropriate error status code (e.g., `500 Internal Server Error`)
-    - Result response contains `OperationOutcome` with error details
-    - This cleanly separates polling errors from operation errors
+4. **Completion**: When the export is ready, the status poll returns:
+    - `200 OK` status code
+    - A `Parameters` resource in the body containing `status` = `completed`, the
+      export metadata, and the `output` entries with their download `location`s
+    - This is the same manifest a synchronous call would return; there is no
+      `303 See Other` redirect and no separate result URL
+5. **Error Handling**: If the export fails, the status poll returns the relevant
+   error status code (e.g. `500 Internal Server Error`) with an
+   `OperationOutcome` body. Polling-transport errors and operation failures are
+   distinguished by the status code on the poll response itself.
 7. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
     - Client sends `DELETE` request to the status polling URL
     - Server responds with `202 Accepted`
     - Subsequent status requests return `404 Not Found`
     - Server SHOULD clean up any partial results
-8. **Result URL Lifetime**:
-   Result URLs SHALL remain valid for at least 24 hours after export completion:
-    - Servers SHOULD support multiple retrievals of the same result
-    - Servers MAY include an `Expires` header to indicate result URL expiration
+8. **Result Lifetime**:
+   The completed status URL (which returns the manifest) and the
+   `output.location` download URLs SHALL remain valid for at least 24 hours after
+   export completion:
+    - Servers SHOULD support multiple retrievals of the completed manifest
+    - Servers MAY include an `Expires` header to indicate when the URLs expire
     - Clients should retrieve results promptly but can retry within the validity window
 9. **Access Control**:
-   Servers SHALL protect status and result URLs with appropriate access controls:
+   Servers SHALL protect status and download URLs with appropriate access controls:
     - Same authorization context as the original request, OR
     - Non-guessable URLs (e.g., cryptographically random tokens)
     - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
@@ -704,25 +706,7 @@ Accept: application/fhir+json
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
 ```
 
-Response indicates completion with redirect to result URL:
-
-```http
-HTTP/1.1 303 See Other
-Location: https://example.com/fhir/export/550e8400-e29b-41d4-a716-446655440000/result
-```
-
-**Step 6: Result Retrieval**
-
-Client follows the `Location` header to retrieve the final results:
-
-```http
-GET /fhir/export/550e8400-e29b-41d4-a716-446655440000/result HTTP/1.1
-Host: example.com
-Accept: application/fhir+json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
-```
-
-Response contains the export results:
+The status poll returns `200 OK` with the manifest in the body; there is no redirect:
 
 ```http
 HTTP/1.1 200 OK
@@ -777,7 +761,7 @@ Expires: Wed, 04 Mar 2026 14:30:42 GMT
 }
 ```
 
-**Step 7: Download Files**
+**Step 6: Download Files**
 
 Client downloads each file:
 

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -149,11 +149,11 @@ Provides ViewDefinitions that serve as table sources for the SQL queries. These 
 
 ##### Export Control
 
-| Name             | Type    | Min | Max | Description                                                                                           |
-| ---------------- | ------- | --- | --- | ----------------------------------------------------------------------------------------------------- |
-| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
-| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
-| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                         |
+| Name             | Type    | Min | Max | Description                                                                                   |
+| ---------------- | ------- | --- | --- | --------------------------------------------------------------------------------------------- |
+| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                          |
+| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`. [Details](#format-parameter-clarification) |
+| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                 |
 
 {:.table-data}
 
@@ -192,19 +192,16 @@ Servers SHALL document which reference formats they support in their CapabilityS
 
 ##### Format Parameter Clarification
 
-The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`) and the
-default are defined in
+The supported formats (`json`, `ndjson`, `csv`, `parquet`) and the default are
+defined in
 [Common Operation Behavior](operations-common.html#output-formats) and apply to
-this operation:
+this operation. The `fhir` format is available on the run operations only:
 
 - It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
-  support `parquet` and `fhir`, and SHALL document supported formats in the
+  support `parquet`, and SHALL document supported formats in the
   CapabilityStatement.
 - If `_format` is omitted, the server SHALL produce the export output in `ndjson`
   format.
-- `_format=fhir` exports each output as a file of newline-delimited FHIR
-  `Parameters` rows (media type `application/fhir+ndjson`); see
-  [FHIR Format](operations-common.html#fhir-format).
 
 ##### Patient Parameter Clarification
 

--- a/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
@@ -21,9 +21,9 @@ the path).
 
 #### Output Parameter
 
-| Name   | Type     | Description                                                                                          |
-| ------ | -------- | ---------------------------------------------------------------------------------------------------- |
-| return | Resource | Query results. Returns Binary for flat formats (csv, json, ndjson, parquet) or Parameters for `fhir`. The Binary is a raw stream in the format's native media type, not a serialized Binary envelope. See [Return Representation](operations-common.html#return-representation) |
+| Name   | Type   | Description                                                                                                                                                                                                                               |
+| ------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| return | Binary | Query results as a raw stream in the format's native media type, not a serialized `Binary` envelope (a `Parameters` resource when `_format=fhir` is requested). See [Return Representation](operations-common.html#return-representation) |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
@@ -23,7 +23,7 @@ the path).
 
 | Name   | Type     | Description                                                                                          |
 | ------ | -------- | ---------------------------------------------------------------------------------------------------- |
-| return | Resource | Query results. Returns Binary for flat formats (csv, json, ndjson, parquet) or Parameters for `fhir` |
+| return | Resource | Query results. Returns Binary for flat formats (csv, json, ndjson, parquet) or Parameters for `fhir`. The Binary is a raw stream in the format's native media type, not a serialized Binary envelope. See [Return Representation](operations-common.html#return-representation) |
 
 {:.table-data}
 
@@ -44,15 +44,21 @@ as an error.
 
 #### Format Parameter Clarification
 
-It is RECOMMENDED to support `json`, `ndjson` and `csv` formats by default.
-Servers may support other formats, but they should be explicitly documented in
-the CapabilityStatement.
+The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`), the default,
+the `Accept`-vs-`_format` precedence rule, the raw-vs-envelope representation
+axis, and transfer framing are defined in
+[Common Operation Behavior](operations-common.html) and apply identically to
+this operation:
 
-If `_format` is omitted, the server SHALL return the result in `ndjson` format.
-
-Servers MAY honour the HTTP `Accept` header to negotiate an alternative format
-when `_format` is not supplied. When `_format` is supplied, its value SHALL
-take precedence over `Accept`.
+- It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
+  support `parquet` and `fhir`, and SHALL document supported formats in the
+  CapabilityStatement.
+- If `_format` is omitted (and no format is derivable from `Accept`), the server
+  SHALL return the result in `ndjson` format.
+- When `_format` is supplied, its value SHALL take precedence over `Accept`.
+- The response of any format MAY use `Transfer-Encoding: chunked`; chunked
+  transfer is independent of the format. See
+  [Streaming and Transfer Encoding](operations-common.html#streaming).
 
 ### Examples
 
@@ -211,7 +217,12 @@ Content-Type: application/fhir+json
 
 #### Response
 
-For flat formats (`csv`, `json`, `ndjson`, `parquet`), the response is a Binary:
+For flat formats (`csv`, `json`, `ndjson`, `parquet`), the response body is the
+raw payload in the format's native media type (the `Binary` stream), not a
+serialized `Binary` resource envelope; `Content-Type` is set to that media type.
+The response MAY be sent with `Transfer-Encoding: chunked` regardless of format.
+See [Return Representation](operations-common.html#return-representation) and
+[Streaming](operations-common.html#streaming).
 
 ```http
 HTTP/1.1 200 OK

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -228,10 +228,10 @@ The `view` parameter is a complex type that can be repeated multiple times to ex
 
 ##### Export Control
 
-| Name             | Type   | Min | Max | Description                                                                                   |
-| ---------------- | ------ | --- | --- | --------------------------------------------------------------------------------------------- |
-| clientTrackingId | string | 0   | 1   | Client-provided tracking ID for the export operation                                          |
-| \_format         | code   | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`. [Details](#format-parameter-clarification) |
+| Name             | Type   | Min | Max | Description                                                                                           |
+| ---------------- | ------ | --- | --- | ----------------------------------------------------------------------------------------------------- |
+| clientTrackingId | string | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
+| \_format         | code   | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -4,14 +4,14 @@
 
 #### Asynchronous Pattern
 
-This operation follows the FHIR Asynchronous Interaction Request Pattern:
+This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and one or more `view` parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
 3. Client polls the status URL for export progress
 4. Server responds with `202 Accepted` while export is in progress (MAY include interim results)
-5. Upon completion, server returns `303 See Other` with `Location` header pointing to result URL
-6. Client GETs the result URL to retrieve final output (identical to synchronous response format)
+5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
+6. Client downloads the exported files from the `output.location` URLs in the manifest
 
 **Note**: This operation uses Parameters resource format instead of Bundle format to:
 
@@ -19,7 +19,7 @@ This operation follows the FHIR Asynchronous Interaction Request Pattern:
 - Allow extensible output metadata specific to export operations
 - Maintain consistency with other FHIR operations
 
-**Note**: The `303 See Other` redirect pattern cleanly separates status polling from result retrieval, eliminating ambiguity around error handling and request header scope.
+**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Interaction Request Pattern (and the Bulk Data pattern it generalises). The operation does not use a `303 See Other` redirect to a separate result resource, so standard async/Bulk Data clients interoperate without special handling.
 
 ##### Async Flow Diagram
 
@@ -79,30 +79,19 @@ This operation follows the FHIR Asynchronous Interaction Request Pattern:
       │                                               │
       │ ┌─────────────────────────────────────────┐   │
       │ │ GET /status/abc123                      │   │
-      │ └─────────────────────────────────────────┘   │
-      │ ─────────────────────────────────────────────>│
-      │                                               │  Step 3: Completion
-      │   ┌─────────────────────────────────────────┐ │  (redirect to result)
-      │   │ 303 See Other                           │ │
-      │   │ Location: /result/abc123                │ │
-      │   └─────────────────────────────────────────┘ │
-      │ <─────────────────────────────────────────────│
-      │                                               │
-      ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┤
-      │                                               │
-      │ ┌─────────────────────────────────────────┐   │
-      │ │ GET /result/abc123                      │   │
       │ │ Accept: application/fhir+json           │   │
       │ └─────────────────────────────────────────┘   │
       │ ─────────────────────────────────────────────>│
-      │                                               │  Step 4: Result
-      │   ┌─────────────────────────────────────────┐ │
+      │                                               │  Step 3: Completion
+      │   ┌─────────────────────────────────────────┐ │  (200 OK + manifest)
       │   │ 200 OK                                  │ │
       │   │ Content-Type: application/fhir+json    │ │
       │   │ Expires: Mon, 21 Jan 2026 16:00:00 GMT │ │
       │   │                                         │ │
       │   │ { "resourceType": "Parameters",         │ │
       │   │   "parameter": [                        │ │
+      │   │     {"name": "status",                  │ │
+      │   │      "valueCode": "completed"},         │ │
       │   │     {"name": "output", "part": [        │ │
       │   │       {"name": "name",                  │ │
       │   │        "valueString": "patients"},      │ │
@@ -119,7 +108,7 @@ This operation follows the FHIR Asynchronous Interaction Request Pattern:
       │ │ GET /export/abc123/patients.ndjson      │   │
       │ └─────────────────────────────────────────┘   │
       │ ─────────────────────────────────────────────>│
-      │                                               │  Step 5: Download
+      │                                               │  Step 4: Download
       │   ┌─────────────────────────────────────────┐ │
       │   │ 200 OK                                  │ │
       │   │ Content-Type: application/fhir+ndjson  │ │
@@ -163,13 +152,6 @@ This operation follows the FHIR Asynchronous Interaction Request Pattern:
   │    │ GET /status/abc123                            │            │
   │    │ ─────────────────────────────────────────────>│            │
   │    │                                               │            │
-  │    │   303 See Other                               │            │
-  │    │   Location: /result/abc123                    │            │
-  │    │ <─────────────────────────────────────────────│            │
-  │    │                                               │            │
-  │    │ GET /result/abc123                            │            │
-  │    │ ─────────────────────────────────────────────>│            │
-  │    │                                               │            │
   │    │   500 Internal Server Error                   │            │
   │    │   { "resourceType": "OperationOutcome",       │            │
   │    │     "issue": [{                               │            │
@@ -206,19 +188,16 @@ Optional filtering parameters:
 
 ##### Status Request
 
-- `Accept` (recommended) - Specifies the format of the status response
-
-##### Result Request
-
-- `Accept` (recommended) - Specifies the format of the final result response
+- `Accept` (recommended) - Specifies the format of the status response, including the completion (`200 OK`) response that carries the manifest
 
 ##### Header Scope
 
-Request headers sent during status polling apply **only to the status response**, not to the final operation result. This separation:
-
-- Allows different content negotiation for status vs. result responses
-- Enables servers to use different formats for interim status (e.g., minimal JSON) vs. final results (e.g., detailed Parameters)
-- Eliminates ambiguity about which response the headers apply to
+Each status-poll request's headers apply to **that poll's response**. Because
+completion is delivered as `200 OK` with the manifest in the body of the
+status-poll response (there is no separate result resource), the `Accept` header
+sent on the completing poll governs the representation of the manifest. This
+allows a client to negotiate a different representation for interim status
+responses (e.g. minimal JSON) than for the final manifest if it chooses.
 
 #### Parameters
 
@@ -298,12 +277,22 @@ For servers that want to support all types of references, it is recommended to f
 
 ##### Format Parameter Clarification
 
-It is RECOMMENDED to support 'json', 'ndjson' and 'csv' formats by default.
-Servers may support other formats, but they should be explicitly documented in the CapabilityStatement.
+The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`) and the
+default are defined in
+[Common Operation Behavior](operations-common.html#output-formats) and apply to
+this operation:
 
-If `_format` is omitted, the server SHALL return the export output in `ndjson` format.
-
-Servers MAY honour the HTTP `Accept` header to negotiate an alternative format when `_format` is not supplied. When `_format` is supplied, its value SHALL take precedence over `Accept`.
+- It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
+  support `parquet` and `fhir`, and SHALL document supported formats in the
+  CapabilityStatement.
+- If `_format` is omitted, the server SHALL produce the export output in `ndjson`
+  format.
+- When `_format` is supplied, its value SHALL take precedence over `Accept`
+  (which here negotiates the format of the *status/manifest* responses, not the
+  exported files).
+- `_format=fhir` exports each output as a file of newline-delimited FHIR
+  `Parameters` rows (media type `application/fhir+ndjson`); see
+  [FHIR Format](operations-common.html#fhir-format).
 
 ##### Patient Parameter Clarification
 
@@ -333,7 +322,9 @@ the server MAY include these resources in a response irrespective of the `_since
 
 #### Output Parameters
 
-Output parameters appear in the **result response** (after following the `303 See Other` redirect), not in status polling responses.
+Output parameters appear in the **completion response** — the `200 OK`
+status-poll response that carries the manifest. They are not present in the
+`202 Accepted` responses returned while the export is still in progress.
 
 ##### Export Identifiers
 
@@ -433,11 +424,11 @@ The $viewdefinition-export operation uses standard HTTP status codes to indicate
 | Status Code               | Description          | When to Use                                                          |
 | ------------------------- | -------------------- | -------------------------------------------------------------------- |
 | 202 Accepted              | In Progress          | Export request accepted or still in progress during polling          |
-| 303 See Other             | Complete             | Export complete, follow `Location` header to retrieve results        |
+| 200 OK                    | Complete             | Export complete; the status-poll response body carries the manifest  |
 | 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers |
 | 404 Not Found             | Not Found            | ViewDefinition not found, or cancelled export status URL             |
 | 422 Unprocessable Entity  | Business Logic Error | Valid request but ViewDefinition is invalid or cannot be processed   |
-| 500 Internal Server Error | Server Error         | Unexpected server error (at result URL indicates operation failure)  |
+| 500 Internal Server Error | Server Error         | Unexpected server error; on a status poll, indicates operation failure |
 
 {:.table-data}
 
@@ -584,31 +575,31 @@ Content-Type: application/fhir+json
     - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
     - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
     - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
-4. **Completion**: When export is ready, server responds with:
-    - `303 See Other` status code
-    - `Location` header pointing to the result URL
-    - Response body is optional (MAY be empty or contain minimal status)
-5. **Result Retrieval**: Client GETs the result URL from the `Location` header:
-    - `200 OK` status code with Parameters resource containing `output` locations
-    - Response format is identical to what a synchronous call would return
-6. **Error Handling**: If export fails:
-    - Status endpoint still returns `303 See Other` with `Location` header
-    - Result URL returns appropriate error status code (e.g., `500 Internal Server Error`)
-    - Result response contains `OperationOutcome` with error details
-    - This cleanly separates polling errors from operation errors
+4. **Completion**: When the export is ready, the status poll returns:
+    - `200 OK` status code
+    - A `Parameters` resource in the body containing `status` = `completed`, the
+      export metadata, and the `output` entries with their download `location`s
+    - This is the same manifest a synchronous call would return; there is no
+      `303 See Other` redirect and no separate result URL
+5. **Error Handling**: If the export fails, the status poll returns the relevant
+   error status code (e.g. `500 Internal Server Error`) with an
+   `OperationOutcome` body. Polling-transport errors and operation failures are
+   distinguished by the status code on the poll response itself.
 7. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
     - Client sends `DELETE` request to the status polling URL
     - Server responds with `202 Accepted`
     - Subsequent status requests return `404 Not Found`
     - Server SHOULD clean up any partial results
-8. **Result URL Lifetime**:
-   Result URLs SHALL remain valid for at least 24 hours after export completion:
-    - Servers SHOULD support multiple retrievals of the same result
-    - Servers MAY include an `Expires` header to indicate result URL expiration
+8. **Result Lifetime**:
+   The completed status URL (which returns the manifest) and the
+   `output.location` download URLs SHALL remain valid for at least 24 hours after
+   export completion:
+    - Servers SHOULD support multiple retrievals of the completed manifest
+    - Servers MAY include an `Expires` header to indicate when the URLs expire
     - Clients should retrieve results promptly but can retry within the validity window
 9. **Access Control**:
-   Servers SHALL protect status and result URLs with appropriate access controls:
+   Servers SHALL protect status and download URLs with appropriate access controls:
     - Same authorization context as the original request, OR
     - Non-guessable URLs (e.g., cryptographically random tokens)
     - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
@@ -853,25 +844,7 @@ Accept: application/fhir+json
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
 ```
 
-Response indicates completion with redirect to result URL:
-
-```http
-HTTP/1.1 303 See Other
-Location: https://example.com/fhir/export/550e8400-e29b-41d4-a716-446655440000/result
-```
-
-**Step 6: Result Retrieval**
-
-Client follows the `Location` header to retrieve the final results:
-
-```http
-GET /fhir/export/550e8400-e29b-41d4-a716-446655440000/result HTTP/1.1
-Host: example.com
-Accept: application/fhir+json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
-```
-
-Response contains the export results (identical to what a synchronous call would return):
+The status poll returns `200 OK` with the manifest in the body (identical to what a synchronous call would return); there is no redirect:
 
 ```http
 HTTP/1.1 200 OK
@@ -943,7 +916,7 @@ Expires: Fri, 16 Jan 2026 14:30:42 GMT
 }
 ```
 
-**Step 7: Download Files**
+**Step 6: Download Files**
 
 Client downloads each file:
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -228,10 +228,11 @@ The `view` parameter is a complex type that can be repeated multiple times to ex
 
 ##### Export Control
 
-| Name             | Type   | Min | Max | Description                                                                                           |
-| ---------------- | ------ | --- | --- | ----------------------------------------------------------------------------------------------------- |
-| clientTrackingId | string | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
-| \_format         | code   | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
+| Name             | Type    | Min | Max | Description                                                                                           |
+| ---------------- | ------- | --- | --- | ----------------------------------------------------------------------------------------------------- |
+| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
+| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
+| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                         |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -4,7 +4,7 @@
 
 #### Asynchronous Pattern
 
-This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
+This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and one or more `view` parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
@@ -13,13 +13,13 @@ This operation follows the [FHIR Asynchronous Interaction Request Pattern](https
 5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
 6. Client downloads the exported files from the `output.location` URLs in the manifest
 
-**Note**: This operation uses Parameters resource format instead of Bundle format to:
+**Note**: This operation uses a FHIR `Parameters` resource as the manifest instead of the Bulk Data JSON manifest object to:
 
 - Provide structured status reporting and metadata
 - Allow extensible output metadata specific to export operations
 - Maintain consistency with other FHIR operations
 
-**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Interaction Request Pattern (and the Bulk Data pattern it generalises). The operation does not use a `303 See Other` redirect to a separate result resource, so standard async/Bulk Data clients interoperate without special handling.
+**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Bulk Data Request Pattern. The operation does not use a `303 See Other` redirect to a separate result resource, so standard Bulk Data clients interoperate without special handling.
 
 ##### Async Flow Diagram
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -111,7 +111,7 @@ This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https:/
       │                                               │  Step 4: Download
       │   ┌─────────────────────────────────────────┐ │
       │   │ 200 OK                                  │ │
-      │   │ Content-Type: application/fhir+ndjson  │ │
+      │   │ Content-Type: application/x-ndjson     │ │
       │   │                                         │ │
       │   │ {"id":"pt1","name":[{"given":["John"]}]}│ │
       │   │ {"id":"pt2","name":[{"given":["Jane"]}]}│ │

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -228,11 +228,11 @@ The `view` parameter is a complex type that can be repeated multiple times to ex
 
 ##### Export Control
 
-| Name             | Type    | Min | Max | Description                                                                                           |
-| ---------------- | ------- | --- | --- | ----------------------------------------------------------------------------------------------------- |
-| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                                  |
-| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`, `fhir`. [Details](#format-parameter-clarification) |
-| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                         |
+| Name             | Type    | Min | Max | Description                                                                                   |
+| ---------------- | ------- | --- | --- | --------------------------------------------------------------------------------------------- |
+| clientTrackingId | string  | 0   | 1   | Client-provided tracking ID for the export operation                                          |
+| \_format         | code    | 0   | 1   | Output format: `csv`, `ndjson`, `parquet`, `json`. [Details](#format-parameter-clarification) |
+| header           | boolean | 0   | 1   | Include CSV headers (default true). Applies only when csv output is requested                 |
 
 {:.table-data}
 
@@ -278,22 +278,19 @@ For servers that want to support all types of references, it is recommended to f
 
 ##### Format Parameter Clarification
 
-The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`) and the
-default are defined in
+The supported formats (`json`, `ndjson`, `csv`, `parquet`) and the default are
+defined in
 [Common Operation Behavior](operations-common.html#output-formats) and apply to
-this operation:
+this operation. The `fhir` format is available on the run operations only:
 
 - It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
-  support `parquet` and `fhir`, and SHALL document supported formats in the
+  support `parquet`, and SHALL document supported formats in the
   CapabilityStatement.
 - If `_format` is omitted, the server SHALL produce the export output in `ndjson`
   format.
 - When `_format` is supplied, its value SHALL take precedence over `Accept`
-  (which here negotiates the format of the *status/manifest* responses, not the
+  (which here negotiates the format of the _status/manifest_ responses, not the
   exported files).
-- `_format=fhir` exports each output as a file of newline-delimited FHIR
-  `Parameters` rows (media type `application/fhir+ndjson`); see
-  [FHIR Format](operations-common.html#fhir-format).
 
 ##### Patient Parameter Clarification
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -583,25 +583,25 @@ Content-Type: application/fhir+json
    error status code (e.g. `500 Internal Server Error`) with an
    `OperationOutcome` body. Polling-transport errors and operation failures are
    distinguished by the status code on the poll response itself.
-7. **Cancellation** (Recommended):
+6. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
     - Client sends `DELETE` request to the status polling URL
     - Server responds with `202 Accepted`
     - Subsequent status requests return `404 Not Found`
     - Server SHOULD clean up any partial results
-8. **Result Lifetime**:
+7. **Result Lifetime**:
    The completed status URL (which returns the manifest) and the
    `output.location` download URLs SHALL remain valid for at least 24 hours after
    export completion:
     - Servers SHOULD support multiple retrievals of the completed manifest
     - Servers MAY include an `Expires` header to indicate when the URLs expire
     - Clients should retrieve results promptly but can retry within the validity window
-9. **Access Control**:
+8. **Access Control**:
    Servers SHALL protect status and download URLs with appropriate access controls:
     - Same authorization context as the original request, OR
     - Non-guessable URLs (e.g., cryptographically random tokens)
     - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
-10. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
+9. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
 
 #### Examples
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
@@ -41,10 +41,16 @@ The operation can process data from:
 
 #### Output Format
 
-The response format is determined by (in order of precedence):
+This operation uses the shared output-format enumeration (`json`, `ndjson`,
+`csv`, `parquet`, `fhir`), content-negotiation rules, and return-representation
+rules defined once in
+[Common Operation Behavior](operations-common.html). Only a summary is repeated
+here.
 
-- **`_format` parameter**: Use shortened format names (`json`, `ndjson`, `csv`, `parquet`)
-- **`Accept` header**: Use standard MIME types (`application/json`, `application/x-ndjson`, `text/csv`, `application/octet-stream`)
+The format is selected by (in order of precedence):
+
+- **`_format` parameter**: shortened format names (`json`, `ndjson`, `csv`, `parquet`, `fhir`)
+- **`Accept` header**: standard MIME types (`application/json`, `application/x-ndjson`, `text/csv`, `application/octet-stream`, `application/fhir+json`)
 
 Examples:
 
@@ -52,6 +58,11 @@ Examples:
 - `_format=ndjson` or `Accept: application/x-ndjson`
 - `_format=csv` or `Accept: text/csv`
 - `_format=parquet` or `Accept: application/octet-stream`
+- `_format=fhir` or `Accept: application/fhir+json`
+
+The `Accept` header also governs a second, independent axis — whether the body
+is the **raw payload** (the default) or a serialized `Binary` resource envelope.
+See [Content Negotiation](operations-common.html#content-negotiation).
 
 #### Filtering
 
@@ -64,9 +75,9 @@ Optional filtering parameters:
 
 #### Response Format
 
-- **Success (200 OK)**: Returns data in requested format
+- **Success (200 OK)**: Returns the raw payload in the requested format, with `Content-Type` set to the format's native media type (not a serialized `Binary` envelope unless a FHIR media type is requested — see [Return Representation](operations-common.html#return-representation))
 - **Error (4xx/5xx)**: Returns `OperationOutcome` resource
-- **Streaming**: MAY use chunked transfer encoding for large result sets
+- **Transfer framing**: The response of **any** format MAY use `Transfer-Encoding: chunked`. Chunked transfer is an HTTP transport choice, independent of the format; it is distinct from incremental result production. See [Streaming and Transfer Encoding](operations-common.html#streaming)
 - **JSON format**: Returns an array of objects
 
 #### Parameters
@@ -115,9 +126,9 @@ Optional filtering parameters:
 
 ##### Output Parameter
 
-| Name   | Type   | Description                                  |
-| ------ | ------ | -------------------------------------------- |
-| return | Binary | The transformed data in the requested format |
+| Name   | Type     | Description                                                                                                       |
+| ------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| return | Resource | Transformed data. `Binary` (a raw stream in the format's native media type) for `csv`/`json`/`ndjson`/`parquet`, or `Parameters` for `_format=fhir`. See [Return Representation](operations-common.html#return-representation) |
 
 {:.table-data}
 
@@ -144,12 +155,20 @@ For servers that want to support all types of references, it is recommended to u
 
 ##### Format Parameter Clarification
 
-It is RECOMMENDED to support 'json', 'ndjson' and 'csv' formats by default.
-Servers may support other formats, but they should be explicitly documented in the CapabilityStatement.
+The supported formats (`json`, `ndjson`, `csv`, `parquet`, `fhir`), the default,
+the `Accept`-vs-`_format` precedence rule, and the optional `fhir` shape are
+defined in [Common Operation Behavior](operations-common.html#output-formats)
+and apply to this operation:
 
-If `_format` is omitted, the server SHALL return the result in `ndjson` format.
-
-Servers MAY honour the HTTP `Accept` header to negotiate an alternative format when `_format` is not supplied. When `_format` is supplied, its value SHALL take precedence over `Accept`.
+- It is RECOMMENDED to support `json`, `ndjson` and `csv` by default; servers MAY
+  support `parquet` and `fhir`, and SHALL document supported formats in the
+  CapabilityStatement.
+- If `_format` is omitted (and no format is derivable from `Accept`), the server
+  SHALL return the result in `ndjson` format.
+- When `_format` is supplied, its value SHALL take precedence over `Accept`.
+- `_format=fhir` returns a `Parameters` resource with one repeating `row` per
+  result row, using the
+  [SQL to FHIR type mapping](OperationDefinition-SQLQueryRun.html#sql-to-fhir-type-mapping).
 
 ##### Patient Parameter Clarification
 
@@ -176,6 +195,25 @@ For Patient- and Group-level requests, the server MAY return resources that are 
 regardless of when the referenced resources were last updated.
 For resources where the server does not maintain a last updated time,
 the server MAY include these resources in a response irrespective of the `_since` value supplied by a client.
+
+##### Resource Parameter and Bundle Inputs {#resource-parameter-clarification}
+
+The `resource` parameter is repeatable and carries the discrete FHIR resources
+to transform instead of using server data. Because a `Bundle` is itself a
+`Resource`, a `Bundle` satisfies the parameter's `Resource` type. To avoid
+ambiguity, the following rule applies:
+
+When a `resource` value is a `Bundle`, the server SHALL **unwrap** it and run the
+ViewDefinition against each `Bundle.entry[*].resource`, exactly as if those
+entries had been supplied as individual repeated `resource` values. The
+`Bundle` itself is not treated as an input resource for the ViewDefinition.
+
+Unwrapping is applied one level deep. Resources within the bundle are evaluated
+against the ViewDefinition's `resource` type just like directly supplied
+resources: entries whose type does not match the ViewDefinition's `resource` are
+ignored. Mixing discrete `resource` values and `Bundle` values in the same
+request is permitted; the effective input is the union of the discrete
+resources and every unwrapped bundle entry.
 
 #### Examples
 
@@ -313,6 +351,57 @@ Transfer-Encoding: chunked
 {"id":"enc-1","patient":"Patient/123","status":"finished","class":"ambulatory","period_start":"2023-01-15T10:00:00Z"}
 {"id":"enc-2","patient":"Patient/123","status":"finished","class":"emergency","period_start":"2023-02-20T14:30:00Z"}
 {"id":"enc-3","patient":"Patient/123","status":"in-progress","class":"inpatient","period_start":"2023-03-01T08:00:00Z"}
+```
+
+##### Example 5: POST with a Bundle of resources
+
+A `Bundle` supplied as a `resource` value is unwrapped; the ViewDefinition runs
+against each entry. This request is equivalent to Example 3, which passed the
+two Patients as discrete `resource` values.
+
+```http
+POST /ViewDefinition/$run HTTP/1.1
+Accept: text/csv
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "Parameters",
+  "parameter": [{
+    "name": "viewResource",
+    "resource": {
+      "resourceType": "ViewDefinition",
+      "resource": "Patient",
+      "select": [{
+        "column": [
+          {"name": "id", "type": "id", "path": "getResourceKey()"},
+          {"name": "birthDate", "type": "date", "path": "birthDate"},
+          {"name": "family", "type": "string", "path": "name.family"},
+          {"name": "given", "type": "string", "path": "name.given"}
+        ]
+      }]
+    }
+  },
+  {
+    "name": "resource",
+    "resource": {
+      "resourceType": "Bundle",
+      "type": "collection",
+      "entry": [
+        { "resource": { "resourceType": "Patient", "id": "pt-1", "name": [{"family": "Cole", "given": ["Joanie"]}], "birthDate": "2012-03-30" } },
+        { "resource": { "resourceType": "Patient", "id": "pt-2", "name": [{"family": "Doe", "given": ["John"]}], "birthDate": "2012-03-30" } }
+      ]
+    }
+  }]
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/csv
+
+id,birthDate,family,given
+pt-1,2012-03-30,Cole,Joanie
+pt-2,2012-03-30,Doe,John
 ```
 
 #### Error Handling

--- a/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
@@ -126,9 +126,9 @@ Optional filtering parameters:
 
 ##### Output Parameter
 
-| Name   | Type     | Description                                                                                                       |
-| ------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| return | Resource | Transformed data. `Binary` (a raw stream in the format's native media type) for `csv`/`json`/`ndjson`/`parquet`, or `Parameters` for `_format=fhir`. See [Return Representation](operations-common.html#return-representation) |
+| Name   | Type   | Description                                                                                                                                                                                                                                  |
+| ------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| return | Binary | Transformed data as a raw stream in the format's native media type, not a serialized `Binary` envelope (a `Parameters` resource when `_format=fhir` is requested). See [Return Representation](operations-common.html#return-representation) |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
@@ -97,10 +97,10 @@ Optional filtering parameters:
 
 ##### Output Control
 
-| Name     | Type    | Scope          | Required | Max | Description                                                       |
-| -------- | ------- | -------------- | -------- | --- | ----------------------------------------------------------------- |
-| \_format | code    | type, instance | No       | 1   | Output format: `json`, `ndjson`, `csv`, `parquet`                 |
-| header   | boolean | type, instance | No       | 1   | Include CSV headers (default: true). Only applies to `csv` format |
+| Name     | Type    | Scope          | Required | Max | Description                                                                                           |
+| -------- | ------- | -------------- | -------- | --- | ----------------------------------------------------------------------------------------------------- |
+| \_format | code    | type, instance | No       | 1   | Output format: `json`, `ndjson`, `csv`, `parquet`, `fhir`. [Details](#format-parameter-clarification) |
+| header   | boolean | type, instance | No       | 1   | Include CSV headers (default: true). Only applies to `csv` format                                     |
 
 {:.table-data}
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionRun-notes.md
@@ -567,7 +567,7 @@ Content-Type: application/fhir+json
     {
       "severity": "error",
       "code": "not-supported",
-      "diagnostics": "Format 'xml' is not supported. Supported formats: json, ndjson, csv, parquet",
+      "diagnostics": "Format 'xml' is not supported. Supported formats: json, ndjson, csv, parquet, fhir",
       "expression": ["_format"]
     }
   ]

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -3,10 +3,10 @@
 This page defines behaviour that is **shared by all four SQL on FHIR data
 operations** so that it is specified once and applied identically across them:
 
-- [`$viewdefinition-run`](OperationDefinition-ViewDefinitionRun.html) — synchronous
-- [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) — synchronous
-- [`$viewdefinition-export`](OperationDefinition-ViewDefinitionExport.html) — asynchronous
-- [`$sqlquery-export`](OperationDefinition-SQLQueryExport.html) — asynchronous
+- [`$viewdefinition-run`](OperationDefinition-ViewDefinitionRun.html) - synchronous
+- [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) - synchronous
+- [`$viewdefinition-export`](OperationDefinition-ViewDefinitionExport.html) - asynchronous
+- [`$sqlquery-export`](OperationDefinition-SQLQueryExport.html) - asynchronous
 
 Each operation page references the relevant subsections below rather than
 restating these rules. Where an operation needs to deviate, that operation's
@@ -42,7 +42,7 @@ Conformance rules that apply to every operation:
 
 Apart from `fhir`, this enumeration and the return-shape rules below are
 identical for all four operations. The two delivery models differ only in
-**how** the bytes reach the client — synchronously in the operation response
+**how** the bytes reach the client - synchronously in the operation response
 (the run operations) or asynchronously as downloadable files (the export
 operations).
 
@@ -67,8 +67,8 @@ type denotes a **binary stream**, not a serialized FHIR `Binary` resource
 envelope. When `_format=fhir` is requested, the response is a `Parameters`
 resource rather than a binary stream (see [FHIR Format](#fhir-format)).
 
-Accordingly — and exactly as for a FHIR `Binary` read over the RESTful API (see
-[Serving Binary Resources](https://www.hl7.org/fhir/binary.html#rest)) — the
+Accordingly - and exactly as for a FHIR `Binary` read over the RESTful API (see
+[Serving Binary Resources](https://www.hl7.org/fhir/binary.html#rest)) - the
 default response body is the **raw payload** in the format's native media type
 (`text/csv`, `application/x-ndjson`, the parquet media type, …), with
 `Content-Type` set to that media type. The server does **not**, by default, wrap
@@ -77,7 +77,7 @@ envelope.
 
 A serialized `Binary` resource (with base64-encoded `data`) is returned **only**
 when the client explicitly asks for a FHIR representation via the `Accept`
-header, and only for formats where the server chooses to support it — see
+header, and only for formats where the server chooses to support it - see
 [Content Negotiation](#content-negotiation). For `_format=fhir`, the result is
 already a FHIR `Parameters` resource, so the raw-vs-envelope question does not
 arise.
@@ -90,13 +90,13 @@ The worked examples on each operation page are normative for the default
 Two independent axes govern the response. They are specified separately so they
 are not conflated:
 
-**Axis 1 — which format (`_format` vs `Accept`).** When `_format` is supplied,
+**Axis 1 - which format (`_format` vs `Accept`).** When `_format` is supplied,
 its value SHALL take precedence over the `Accept` header. When `_format` is not
 supplied, the server MAY honour `Accept` to select an
 [output format](#output-formats); if neither selects a format, the server uses
 `ndjson`.
 
-**Axis 2 — representation (raw payload vs FHIR envelope).** Once the format is
+**Axis 2 - representation (raw payload vs FHIR envelope).** Once the format is
 chosen, the `Accept` header further selects how the payload is represented:
 
 - `Accept: application/octet-stream`, the format's native media type, or no
@@ -134,16 +134,16 @@ framing is governed by HTTP itself, not by this specification.
 
 Two further concepts are independent of each other and of the format:
 
-1. **Transfer framing** — `Transfer-Encoding: chunked` (RFC 9112 §7.1) is an
+1. **Transfer framing** - `Transfer-Encoding: chunked` (RFC 9112 §7.1) is an
    HTTP/1.1 message-framing mechanism. It is independent of `Content-Type` and
-   of `_format`: *any* payload — CSV, JSON, NDJSON, parquet,
-   `application/octet-stream`, or a `Binary` envelope — MAY be sent chunked. The
+   of `_format`: *any* payload - CSV, JSON, NDJSON, parquet,
+   `application/octet-stream`, or a `Binary` envelope - MAY be sent chunked. The
    choice between `Content-Length` and chunked framing depends solely on whether
    the server knows the body size before emitting the first byte, never on the
    format. Servers MAY use chunked transfer encoding for the response of any
    format on either run operation.
 
-2. **Incremental result production** — whether the server can emit output before
+2. **Incremental result production** - whether the server can emit output before
    the full result set is materialized. This is a server/engine capability that
    genuinely varies by format: NDJSON and CSV are trivially row-incremental; a
    JSON array needs bracket/comma bookkeeping; parquet must finalise its footer

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -66,10 +66,10 @@ preserving FHIR typing. The file's media type is `application/fhir+ndjson`.
 
 ## Return Representation and the `Binary` Parameter {#return-representation}
 
-The run operations declare their `return` as `Binary` (or, for `$sqlquery-run`,
-`Resource` — `Binary` for the flat formats and `Parameters` for `_format=fhir`).
-The `Binary` type denotes a **binary stream**, not a serialized FHIR `Binary`
-resource envelope.
+The run operations declare their `return` parameter as `Binary`. The `Binary`
+type denotes a **binary stream**, not a serialized FHIR `Binary` resource
+envelope. When `_format=fhir` is requested, the response is a `Parameters`
+resource rather than a binary stream (see [FHIR Format](#fhir-format)).
 
 Accordingly — and exactly as for a FHIR `Binary` read over the RESTful API (see
 [Serving Binary Resources](https://www.hl7.org/fhir/binary.html#rest)) — the

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -111,6 +111,12 @@ chosen, the `Accept` header further selects how the payload is represented:
   `Binary` resource whose `contentType` is the format's native media type and
   whose `data` is the base64-encoded payload.
 
+Axis 2 applies only to the flat formats (`csv`, `json`, `ndjson`, `parquet`).
+When the chosen format is `fhir`, the response is always the `Parameters`
+resource itself, serialized according to the FHIR media type in the `Accept`
+header (`application/fhir+json` by default); neither the raw-payload nor the
+`Binary`-envelope representation applies.
+
 Because base64 inflates the payload by roughly a third and defeats streaming,
 servers MAY decline the envelope representation for the large/streaming formats
 (`parquet`, `ndjson`): a server that does not support the envelope form for a

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -1,0 +1,168 @@
+# Common Operation Behavior
+
+This page defines behaviour that is **shared by all four SQL on FHIR data
+operations** so that it is specified once and applied identically across them:
+
+- [`$viewdefinition-run`](OperationDefinition-ViewDefinitionRun.html) — synchronous
+- [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) — synchronous
+- [`$viewdefinition-export`](OperationDefinition-ViewDefinitionExport.html) — asynchronous
+- [`$sqlquery-export`](OperationDefinition-SQLQueryExport.html) — asynchronous
+
+Each operation page references the relevant subsections below rather than
+restating these rules. Where an operation needs to deviate, that operation's
+page calls out the deviation explicitly.
+
+## Output Formats (`_format`) {#output-formats}
+
+The four operations share a single enumeration of output formats. The supported
+values, their native media types, and the shape they produce are:
+
+| `_format`  | Native media type             | Shape                                                                 |
+| ---------- | ----------------------------- | --------------------------------------------------------------------- |
+| `csv`      | `text/csv`                    | Header row (unless `header=false`) followed by one row per result row |
+| `json`     | `application/json`            | A single JSON array of row objects                                    |
+| `ndjson`   | `application/x-ndjson`        | One JSON object per line, one line per result row                     |
+| `parquet`  | `application/vnd.apache.parquet` | Apache Parquet file                                                |
+| `fhir`     | `application/fhir+json`       | A FHIR `Parameters` resource with one repeating `row` per result row (see [FHIR Format](#fhir-format)) |
+
+{:.table-data}
+
+Conformance rules that apply to every operation:
+
+- It is RECOMMENDED to support `json`, `ndjson` and `csv` by default. Servers
+  MAY support `parquet` and `fhir`; any format a server supports SHALL be
+  declared in its CapabilityStatement, and any format it does not support SHALL
+  be rejected with `400 Bad Request` and an `OperationOutcome`.
+- If `_format` is omitted and the format cannot be derived from the `Accept`
+  header (see [Content Negotiation](#content-negotiation)), the server SHALL use
+  `ndjson`.
+- `header` applies only to `csv` and defaults to `true`.
+
+This enumeration and the return-shape rules below are identical for all four
+operations. The two delivery models differ only in **how** the bytes reach the
+client — synchronously in the operation response (the run operations) or
+asynchronously as downloadable files (the export operations).
+
+### FHIR Format (`_format=fhir`) {#fhir-format}
+
+`fhir` is an OPTIONAL format that returns result rows as typed FHIR values
+rather than as text or binary. It is available, at the server's option, on all
+four operations.
+
+For the **synchronous** run operations, the result is a `Parameters` resource
+with one repeating `row` parameter per result row; each row's columns are
+`part`s carrying the appropriate `value[x]`. A query that yields no rows returns
+a `Parameters` resource with no `parameter` elements. SQL `NULL` is represented
+by omitting the corresponding `part`. The column-type-to-`value[x]` mapping is
+defined in
+[SQL to FHIR type mapping](OperationDefinition-SQLQueryRun.html#sql-to-fhir-type-mapping).
+
+For the **asynchronous** export operations, each `output` entry is delivered as
+a file of **newline-delimited `Parameters` resources** — one `Parameters`
+resource per line, each structured exactly as a single synchronous `row`
+parameter's `part` list (i.e. one line per result row). This keeps `fhir`
+exports row-incremental and consistent with the other file formats, while
+preserving FHIR typing. The file's media type is `application/fhir+ndjson`.
+
+## Return Representation and the `Binary` Parameter {#return-representation}
+
+The run operations declare their `return` as `Binary` (or, for `$sqlquery-run`,
+`Resource` — `Binary` for the flat formats and `Parameters` for `_format=fhir`).
+The `Binary` type denotes a **binary stream**, not a serialized FHIR `Binary`
+resource envelope.
+
+Accordingly — and exactly as for a FHIR `Binary` read over the RESTful API (see
+[Serving Binary Resources](https://www.hl7.org/fhir/binary.html#rest)) — the
+default response body is the **raw payload** in the format's native media type
+(`text/csv`, `application/x-ndjson`, the parquet media type, …), with
+`Content-Type` set to that media type. The server does **not**, by default, wrap
+the payload in a `{"resourceType":"Binary", "contentType":"…", "data":"<base64>"}`
+envelope.
+
+A serialized `Binary` resource (with base64-encoded `data`) is returned **only**
+when the client explicitly asks for a FHIR representation via the `Accept`
+header, and only for formats where the server chooses to support it — see
+[Content Negotiation](#content-negotiation). For `_format=fhir`, the result is
+already a FHIR `Parameters` resource, so the raw-vs-envelope question does not
+arise.
+
+The worked examples on each operation page are normative for the default
+(raw-payload) case.
+
+## Content Negotiation {#content-negotiation}
+
+Two independent axes govern the response. They are specified separately so they
+are not conflated:
+
+**Axis 1 — which format (`_format` vs `Accept`).** When `_format` is supplied,
+its value SHALL take precedence over the `Accept` header. When `_format` is not
+supplied, the server MAY honour `Accept` to select an
+[output format](#output-formats); if neither selects a format, the server uses
+`ndjson`.
+
+**Axis 2 — representation (raw payload vs FHIR envelope).** Once the format is
+chosen, the `Accept` header further selects how the payload is represented:
+
+- `Accept: application/octet-stream`, the format's native media type, or no
+  `Accept` header (the default) → the **raw payload** in the chosen format, with
+  `Content-Type` set to the format's native media type. Chunked framing is
+  permitted (see [Streaming](#streaming)).
+- `Accept: application/fhir+json` or `application/fhir+xml` → a serialized
+  `Binary` resource whose `contentType` is the format's native media type and
+  whose `data` is the base64-encoded payload.
+
+Because base64 inflates the payload by roughly a third and defeats streaming,
+servers MAY decline the envelope representation for the large/streaming formats
+(`parquet`, `ndjson`): a server that does not support the envelope form for a
+given format SHALL respond `406 Not Acceptable` with an `OperationOutcome`
+rather than silently returning raw bytes under a FHIR media type. Support for
+the envelope representation per format SHOULD be documented in the
+CapabilityStatement.
+
+These two axes are distinct: Axis 1 decides *what* is encoded, Axis 2 decides
+*how* it is wrapped.
+
+## Streaming and Transfer Encoding {#streaming}
+
+Two further concepts are independent of each other and of the format:
+
+1. **Transfer framing** — `Transfer-Encoding: chunked` (RFC 9112 §7.1) is an
+   HTTP/1.1 message-framing mechanism. It is independent of `Content-Type` and
+   of `_format`: *any* payload — CSV, JSON, NDJSON, parquet,
+   `application/octet-stream`, or a `Binary` envelope — MAY be sent chunked. The
+   choice between `Content-Length` and chunked framing depends solely on whether
+   the server knows the body size before emitting the first byte, never on the
+   format. Servers MAY use chunked transfer encoding for the response of any
+   format on any of the four operations; for the export operations the same
+   applies to the file downloads, while the operation response itself follows
+   the [asynchronous model](#asynchronous-delivery).
+
+2. **Incremental result production** — whether the server can emit output before
+   the full result set is materialized. This is a server/engine capability that
+   genuinely varies by format: NDJSON and CSV are trivially row-incremental; a
+   JSON array needs bracket/comma bookkeeping; parquet must finalise its footer
+   last but can still flush row groups progressively. Incremental production is
+   neither required nor implied by chunked transfer encoding, and chunked
+   transfer encoding is not reserved for "streamable" formats.
+
+## Asynchronous Delivery {#asynchronous-delivery}
+
+The two export operations conform to the
+[FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html).
+In particular, on completion they follow that pattern's completion response
+exactly:
+
+- **Kick-off** → `202 Accepted` with a `Content-Location` header carrying the
+  status (polling) URL.
+- **Polling while processing** → `202 Accepted`, optionally with `Retry-After`
+  and `X-Progress`, and an optional interim status body.
+- **Completion** → `200 OK` whose body is the manifest `Parameters` resource
+  (`exportId`, `status`, `_format`, the export-timing parameters, and the
+  repeating `output` entries with their `location` download URLs). The manifest
+  is returned **in the body of the status-poll response**; there is no
+  `303 See Other` redirect and no separate result resource to follow.
+- **Failure** → the status poll returns the relevant error status code (e.g.
+  `500 Internal Server Error`) with an `OperationOutcome` body.
+
+File downloads referenced by `output.location` are independent HTTP responses
+and MAY use any framing (including chunked) per [Streaming](#streaming).

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -130,6 +130,12 @@ These two axes are distinct: Axis 1 decides *what* is encoded, Axis 2 decides
 
 ## Streaming and Transfer Encoding {#streaming}
 
+This section applies to the two synchronous run operations, whose responses
+carry the result payload. It does not apply to the export operations: their
+responses follow the [asynchronous model](#asynchronous-delivery), and the
+files they produce are downloaded as ordinary HTTP responses whose transfer
+framing is governed by HTTP itself, not by this specification.
+
 Two further concepts are independent of each other and of the format:
 
 1. **Transfer framing** — `Transfer-Encoding: chunked` (RFC 9112 §7.1) is an
@@ -139,9 +145,7 @@ Two further concepts are independent of each other and of the format:
    choice between `Content-Length` and chunked framing depends solely on whether
    the server knows the body size before emitting the first byte, never on the
    format. Servers MAY use chunked transfer encoding for the response of any
-   format on any of the four operations; for the export operations the same
-   applies to the file downloads, while the operation response itself follows
-   the [asynchronous model](#asynchronous-delivery).
+   format on either run operation.
 
 2. **Incremental result production** — whether the server can emit output before
    the full result set is materialized. This is a server/engine capability that
@@ -175,5 +179,6 @@ it is a FHIR `Parameters` resource rather than the Bulk Data JSON manifest
 object. The flow, status codes, and headers are otherwise as the pattern
 specifies.
 
-File downloads referenced by `output.location` are independent HTTP responses
-and MAY use any framing (including chunked) per [Streaming](#streaming).
+File downloads referenced by `output.location` are independent HTTP responses;
+their transfer framing is governed by HTTP itself and is not constrained by
+this specification.

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -148,7 +148,7 @@ Two further concepts are independent of each other and of the format:
 ## Asynchronous Delivery {#asynchronous-delivery}
 
 The two export operations conform to the
-[FHIR Asynchronous Interaction Request Pattern](https://www.hl7.org/fhir/async-bulk.html).
+[FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html).
 In particular, on completion they follow that pattern's completion response
 exactly:
 
@@ -163,6 +163,11 @@ exactly:
   `303 See Other` redirect and no separate result resource to follow.
 - **Failure** → the status poll returns the relevant error status code (e.g.
   `500 Internal Server Error`) with an `OperationOutcome` body.
+
+The deliberate deviation from that pattern is the manifest's representation:
+it is a FHIR `Parameters` resource rather than the Bulk Data JSON manifest
+object. The flow, status codes, and headers are otherwise as the pattern
+specifies.
 
 File downloads referenced by `output.location` are independent HTTP responses
 and MAY use any framing (including chunked) per [Streaming](#streaming).

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -14,55 +14,51 @@ page calls out the deviation explicitly.
 
 ## Output Formats (`_format`) {#output-formats}
 
-The four operations share a single enumeration of output formats. The supported
-values, their native media types, and the shape they produce are:
+The four operations share a single enumeration of output formats, with one
+exception: `fhir` applies to the run operations only. The supported values,
+their native media types, and the shape they produce are:
 
-| `_format`  | Native media type             | Shape                                                                 |
-| ---------- | ----------------------------- | --------------------------------------------------------------------- |
-| `csv`      | `text/csv`                    | Header row (unless `header=false`) followed by one row per result row |
-| `json`     | `application/json`            | A single JSON array of row objects                                    |
-| `ndjson`   | `application/x-ndjson`        | One JSON object per line, one line per result row                     |
-| `parquet`  | `application/vnd.apache.parquet` | Apache Parquet file                                                |
-| `fhir`     | `application/fhir+json`       | A FHIR `Parameters` resource with one repeating `row` per result row (see [FHIR Format](#fhir-format)) |
+| `_format` | Native media type                | Shape                                                                                                                       |
+| --------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `csv`     | `text/csv`                       | Header row (unless `header=false`) followed by one row per result row                                                       |
+| `json`    | `application/json`               | A single JSON array of row objects                                                                                          |
+| `ndjson`  | `application/x-ndjson`           | One JSON object per line, one line per result row                                                                           |
+| `parquet` | `application/vnd.apache.parquet` | Apache Parquet file                                                                                                         |
+| `fhir`    | `application/fhir+json`          | A FHIR `Parameters` resource with one repeating `row` per result row; run operations only (see [FHIR Format](#fhir-format)) |
 
 {:.table-data}
 
 Conformance rules that apply to every operation:
 
 - It is RECOMMENDED to support `json`, `ndjson` and `csv` by default. Servers
-  MAY support `parquet` and `fhir`; any format a server supports SHALL be
-  declared in its CapabilityStatement, and any format it does not support SHALL
-  be rejected with `400 Bad Request` and an `OperationOutcome`.
+  MAY support `parquet`, and MAY support `fhir` on the run operations; any
+  format a server supports SHALL be declared in its CapabilityStatement, and
+  any format it does not support SHALL be rejected with `400 Bad Request` and
+  an `OperationOutcome`.
 - If `_format` is omitted and the format cannot be derived from the `Accept`
   header (see [Content Negotiation](#content-negotiation)), the server SHALL use
   `ndjson`.
 - `header` applies only to `csv` and defaults to `true`.
 
-This enumeration and the return-shape rules below are identical for all four
-operations. The two delivery models differ only in **how** the bytes reach the
-client — synchronously in the operation response (the run operations) or
-asynchronously as downloadable files (the export operations).
+Apart from `fhir`, this enumeration and the return-shape rules below are
+identical for all four operations. The two delivery models differ only in
+**how** the bytes reach the client — synchronously in the operation response
+(the run operations) or asynchronously as downloadable files (the export
+operations).
 
 ### FHIR Format (`_format=fhir`) {#fhir-format}
 
 `fhir` is an OPTIONAL format that returns result rows as typed FHIR values
-rather than as text or binary. It is available, at the server's option, on all
-four operations.
+rather than as text or binary. It is available, at the server's option, on the
+two synchronous run operations only; it is not available on the export
+operations, whose outputs are flat files.
 
-For the **synchronous** run operations, the result is a `Parameters` resource
-with one repeating `row` parameter per result row; each row's columns are
-`part`s carrying the appropriate `value[x]`. A query that yields no rows returns
-a `Parameters` resource with no `parameter` elements. SQL `NULL` is represented
-by omitting the corresponding `part`. The column-type-to-`value[x]` mapping is
-defined in
+The result is a `Parameters` resource with one repeating `row` parameter per
+result row; each row's columns are `part`s carrying the appropriate `value[x]`.
+A query that yields no rows returns a `Parameters` resource with no `parameter`
+elements. SQL `NULL` is represented by omitting the corresponding `part`. The
+column-type-to-`value[x]` mapping is defined in
 [SQL to FHIR type mapping](OperationDefinition-SQLQueryRun.html#sql-to-fhir-type-mapping).
-
-For the **asynchronous** export operations, each `output` entry is delivered as
-a file of **newline-delimited `Parameters` resources** — one `Parameters`
-resource per line, each structured exactly as a single synchronous `row`
-parameter's `part` list (i.e. one line per result row). This keeps `fhir`
-exports row-incremental and consistent with the other file formats, while
-preserving FHIR typing. The file's media type is `application/fhir+ndjson`.
 
 ## Return Representation and the `Binary` Parameter {#return-representation}
 

--- a/input/pagecontent/operations.md
+++ b/input/pagecontent/operations.md
@@ -40,8 +40,8 @@ And use standard tools like Apache Spark, AWS Athena or other tools to analyze d
 2. The server returns `202 Accepted` with `Content-Location` header pointing to status URL.
 3. The client polls the status URL:
     - Server returns `202 Accepted` while processing (MAY include interim results)
-    - Server returns `303 See Other` with `Location` header when complete
-4. The client follows the `Location` header to retrieve final results with output URLs.
+    - Server returns `200 OK` with the manifest (output URLs) in the body when complete
+4. The client reads the output URLs from the completion manifest.
 5. The client can then:
     - Download exported files from the output URLs
     - Load them into a data warehouse or analyze with tools like Apache Spark or Amazon Athena
@@ -95,6 +95,13 @@ Administrative bodies can request bulk reports for different populations and met
 [See Run Bulk Queries](OperationDefinition-SQLQueryRun.html)
 
 ## API
+
+Behaviour shared by the four data operations (`$viewdefinition-run`,
+`$sqlquery-run`, `$viewdefinition-export`, `$sqlquery-export`) — the output
+format set, return representation, content negotiation, transfer framing, and
+the asynchronous completion response — is specified once in
+[Common Operation Behavior](operations-common.html). The operation pages below
+reference it rather than restating it.
 
 ### CapabilityStatement
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -76,6 +76,7 @@ menu:
   Artifacts: artifacts.html
   Operations:
     Overview: operations.html
+    Common Behavior: operations-common.html
     CapabilityStatement: operations-capability.html
     $viewdefinition-export: OperationDefinition-ViewDefinitionExport.html
     $viewdefinition-run: OperationDefinition-ViewDefinitionRun.html


### PR DESCRIPTION
## Purpose

Fixes the six spec-inconsistency issues I filed against the four sibling data operations (`$viewdefinition-run`, `$sqlquery-run`, `$viewdefinition-export`, `$sqlquery-export`): #358, #359, #360, #361, #362, #363.

Every issue's recommendation asked for the resolution to live **once** in a shared section the operations reference, rather than being restated (and contradicted) per operation. This PR does exactly that.

## Approach

New page **`operations-common.md` — "Common Operation Behavior"** (added under the Operations menu) defines the shared rules once. The four operation pages now reference it and drop their divergent wording.

## Issue-by-issue

| Issue | Resolution |
|-------|-----------|
| **#358** `Binary` vs raw payload | The `return` `Binary` denotes a **raw binary stream** in the format's native media type — *not* a serialized `Binary` JSON envelope — exactly as a FHIR `Binary` read under `Accept: application/octet-stream`. The envelope form is returned only when a FHIR media type is requested. Worked examples are normative for the default case. |
| **#359** Bundle unwrap | A `Bundle` passed as a `resource` value to `$viewdefinition-run` is **unwrapped**: the view runs against each `Bundle.entry[*].resource`. Added the rule and a worked example equivalent to the discrete-resource example. |
| **#360** format set / return type | One shared `_format` enumeration (`csv`/`json`/`ndjson`/`parquet`/`fhir`) and one return-shape matrix across all four operations. **`fhir` promoted to a first-class optional format** on all four, including async semantics for exports (newline-delimited `Parameters` rows, `application/fhir+ndjson`). `$viewdefinition-run` `return` widened to `Resource` (`Binary`\|`Parameters`); the redundant `SQLQueryRunOutputFormatCodes` value set is removed in favour of `OutputFormatCodes` (which already contained all five codes). |
| **#361** streaming | `Transfer-Encoding: chunked` is stated as **transport framing usable with any format**, explicitly distinct from incremental result production; the language now applies to all four operations, not just `$viewdefinition-run`. |
| **#362** `Accept` semantics | The **raw-payload vs `Binary`-envelope** axis is defined as separate from the `_format`-vs-`Accept` precedence axis, with per-format guidance (servers MAY decline the envelope form for parquet/ndjson and return `406`). |
| **#363** async completion | Both export operations are **aligned with the cited FHIR Asynchronous Interaction Request Pattern**: completion is `200 OK` with the manifest in the status-poll body. The `303 See Other` redirect and separate result resource are removed. Flow diagrams (ASCII + mermaid), operation-flow steps, status-code tables, header-scope notes, and worked examples updated accordingly. |

## Decisions made (open to committee revision)

Two issues offered a genuine fork; the directions taken here:
- **#360** → promote `fhir` everywhere (optional) rather than removing it from `$sqlquery-run`.
- **#363** → conform to the async pattern (`200 OK` + inline manifest) rather than documenting the `303` as a deviation.

## Validation

- `sushi .` → **0 errors** (value-set count drops 4→3 with the redundant set removed). The one warning (duplicate `OutputFormatCodes`/`ExportStatusCodes` names) is pre-existing.
- Full IG Publisher QA should run in CI.

Closes #358, closes #359, closes #360, closes #361, closes #362, closes #363.