### PR TITLE
Align async export operations to the simplified async interaction pattern

### DIFF
--- a/input/fsh/operations.fsh
+++ b/input/fsh/operations.fsh
@@ -437,7 +437,7 @@ Instance: SQLQueryExport
 Usage: #definition
 InstanceOf: OperationDefinition
 Title: "SQLQuery Export"
-Description: "Export SQLQuery Library results asynchronously using the FHIR Asynchronous Bulk Data Request Pattern."
+Description: "Export SQLQuery Library results asynchronously using the FHIR Asynchronous Interaction Request Pattern."
 
 * id = "SQLQueryExport"
 * url = "http://sql-on-fhir.org/OperationDefinition/$sqlquery-export"

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-intro.md
@@ -1,4 +1,4 @@
-Export SQLQuery Library results asynchronously using the FHIR Asynchronous Bulk Data Request Pattern.
+Export SQLQuery Library results asynchronously using the FHIR Asynchronous Interaction Request Pattern.
 
 **Use Cases:**
 
@@ -19,8 +19,9 @@ Export SQLQuery Library results asynchronously using the FHIR Asynchronous Bulk 
 
 1. Client sends request with `Prefer: respond-async` header
 2. Server returns `202 Accepted` with `Content-Location` polling URL
-3. Client polls for status until the poll returns `200 OK` with the manifest in the body
-4. Client downloads exported files from the `output.location` URLs in the manifest
+3. Client polls for status until the poll returns `303 See Other` with the result URL in the `Location` header
+4. Client fetches the result URL, which returns the manifest with `200 OK`
+5. Client downloads exported files from the `output.location` URLs in the manifest
 
 This operation combines the query source and parameter binding from
 [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) with the asynchronous

--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -4,22 +4,17 @@
 
 #### Asynchronous Pattern
 
-This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
+This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://build.fhir.org/ig/HL7/api-incubator-ig/branches/simplified-async-interaction/async-interaction.html); the asynchronous flow is specified once in [Common Operation Behavior - Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and query source parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
 3. Client polls the status URL for export progress
 4. Server responds with `202 Accepted` while export is in progress (MAY include interim results)
-5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
-6. Client downloads the exported files from the `output.location` URLs in the manifest
+5. Once the export has finished (successfully or not), the status poll returns `303 See Other` with a `Location` header carrying the result URL and an empty body
+6. Client fetches the result URL; a successful export returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …), and a failed export returns the error status code with an `OperationOutcome`
+7. Client downloads the exported files from the `output.location` URLs in the manifest
 
-**Note**: This operation uses a FHIR `Parameters` resource as the manifest instead of the Bulk Data JSON manifest object to:
-
-- Provide structured status reporting and metadata
-- Allow extensible output metadata specific to export operations
-- Maintain consistency with other FHIR operations
-
-**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Bulk Data Request Pattern. The operation does not use a `303 See Other` redirect to a separate result resource, so standard Bulk Data clients interoperate without special handling.
+The result resource for this operation is the manifest `Parameters` resource described under [Output Parameters](#output-parameters). Clients MUST treat the status and result URLs as opaque values.
 
 ##### Async Flow Diagram
 
@@ -43,11 +38,17 @@ sequenceDiagram
     rect rgb(240, 255, 240)
     Note over C,S: Step 3: Completion
     C->>S: GET /status/abc123
+    S-->>C: 303 See Other<br/>Location: /result/abc123<br/>(empty body)
+    end
+
+    rect rgb(255, 255, 240)
+    Note over C,S: Step 4: Result fetch
+    C->>S: GET /result/abc123
     S-->>C: 200 OK<br/>Body: Parameters{status: completed, output: [{name, location}]}
     end
 
     rect rgb(255, 248, 240)
-    Note over C,S: Step 4: Download
+    Note over C,S: Step 5: Download
     C->>S: GET /export/abc123/bp-results.csv
     S-->>C: 200 OK<br/>Content-Type: text/csv<br/>Body: patient_id,systolic,...
     end
@@ -74,6 +75,8 @@ sequenceDiagram
     participant S as Server
 
     C->>S: GET /status/abc123
+    S-->>C: 303 See Other<br/>Location: /result/abc123<br/>(empty body)
+    C->>S: GET /result/abc123
     S-->>C: 500 Internal Server Error<br/>Body: OperationOutcome{severity: error, diagnostics: ...}
 ```
 
@@ -101,16 +104,20 @@ Optional filtering parameters:
 
 ##### Status Request
 
-- `Accept` (recommended) - Specifies the format of the status response, including the completion (`200 OK`) response that carries the manifest
+- `Accept` (recommended) - Specifies the format of interim status responses and error responses on the status URL; the completing poll returns `303 See Other` with an empty body
+
+##### Result Request
+
+- `Accept` (recommended) - Specifies the representation of the result: the manifest `Parameters` resource on success, or the `OperationOutcome` on failure
 
 ##### Header Scope
 
-Each status-poll request's headers apply to **that poll's response**. Because
-completion is delivered as `200 OK` with the manifest in the body of the
-status-poll response (there is no separate result resource), the `Accept` header
-sent on the completing poll governs the representation of the manifest. This
-allows a client to negotiate a different representation for interim status
-responses (e.g. minimal JSON) than for the final manifest if it chooses.
+Each request's headers apply to **that request's response**. Because
+completion is delivered as `303 See Other` with an empty body, the `Accept`
+header that governs the representation of the manifest is the one sent on the
+result `GET`, not the one sent on the completing status poll. This allows a
+client to negotiate a different representation for interim status responses
+(e.g. minimal JSON) than for the final manifest if it chooses.
 
 #### Parameters
 
@@ -241,9 +248,10 @@ SQLQuery profile for the binding rules and the mapping from
 
 #### Output Parameters
 
-Output parameters appear in the **completion response** — the `200 OK`
-status-poll response that carries the manifest. They are not present in the
-`202 Accepted` responses returned while the export is still in progress.
+Output parameters form the **manifest** - the `Parameters` resource returned
+with `200 OK` from the result URL after the completing poll's `303 See Other`
+redirect. They are not present in the `202 Accepted` responses returned while
+the export is still in progress.
 
 ##### Export Identifiers
 
@@ -310,21 +318,21 @@ For large exports, servers MAY partition the output into multiple files. When pa
 
 ```json
 {
-    "name": "output",
-    "part": [
-        {
-            "name": "name",
-            "valueString": "patient_bp_results"
-        },
-        {
-            "name": "location",
-            "valueUri": "https://example.com/export/123/patient_bp_results.part1.csv"
-        },
-        {
-            "name": "location",
-            "valueUri": "https://example.com/export/123/patient_bp_results.part2.csv"
-        }
-    ]
+  "name": "output",
+  "part": [
+    {
+      "name": "name",
+      "valueString": "patient_bp_results"
+    },
+    {
+      "name": "location",
+      "valueUri": "https://example.com/export/123/patient_bp_results.part1.csv"
+    },
+    {
+      "name": "location",
+      "valueUri": "https://example.com/export/123/patient_bp_results.part2.csv"
+    }
+  ]
 }
 ```
 
@@ -336,14 +344,16 @@ Clients MUST download all parts to obtain the complete dataset.
 
 The $sqlquery-export operation uses standard HTTP status codes to indicate the outcome:
 
-| Status Code               | Description          | When to Use                                                          |
-| ------------------------- | -------------------- | -------------------------------------------------------------------- |
-| 202 Accepted              | In Progress          | Export request accepted or still in progress during polling          |
-| 200 OK                    | Complete             | Export complete; the status-poll response body carries the manifest  |
-| 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers |
-| 404 Not Found             | Not Found            | SQLQuery Library not found, or cancelled export status URL           |
-| 422 Unprocessable Entity  | Business Logic Error | Valid request but query is invalid or cannot be executed             |
-| 500 Internal Server Error | Server Error         | Unexpected server error; on a status poll, indicates operation failure |
+| Status Code               | Description          | When to Use                                                                         |
+| ------------------------- | -------------------- | ----------------------------------------------------------------------------------- |
+| 202 Accepted              | In Progress          | Export request accepted, still in progress during polling, or cancellation accepted |
+| 303 See Other             | Job Finished         | Export finished (successfully or not); `Location` header carries the result URL     |
+| 200 OK                    | Result Available     | Result URL returns the manifest `Parameters`; download URLs return the files        |
+| 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers                |
+| 404 Not Found             | Not Found            | SQLQuery Library not found, or cancelled export status URL                          |
+| 422 Unprocessable Entity  | Business Logic Error | Valid request but query is invalid or cannot be executed                            |
+| 429 Too Many Requests     | Excessive Polling    | Client is polling too frequently; back off exponentially, guided by `Retry-After`   |
+| 500 Internal Server Error | Server Error         | Unexpected server error; on the result URL, the failure outcome of the export       |
 
 {:.table-data}
 
@@ -455,43 +465,51 @@ Content-Type: application/fhir+json
 
 1. **Kick-off Request**: Client sends `POST Library/$sqlquery-export` with `Prefer: respond-async` header and one or more `query` parameters.
 2. **Kick-off Response**: Server responds with:
-    - `202 Accepted` status code
-    - `Content-Location` header with the absolute URL for subsequent status requests (polling location)
-    - Parameters resource with `status` parameter set to `accepted` and `location` parameter
-    - If request is not valid or cannot be processed, server responds with `400 Bad Request` and `OperationOutcome` resource in the body.
+   - `202 Accepted` status code
+   - `Content-Location` header with the absolute URL for subsequent status requests (polling location)
+   - Parameters resource with `status` parameter set to `accepted` and `location` parameter
+   - If request is not valid or cannot be processed, server responds with `400 Bad Request` and `OperationOutcome` resource in the body.
 3. **Status Polling**: Client polls the polling location to get status of the export:
-    - **In Progress**: `202 Accepted` with optional Parameters resource for interim status
-    - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
-    - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
-    - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
-4. **Completion**: When the export is ready, the status poll returns:
-    - `200 OK` status code
-    - A `Parameters` resource in the body containing `status` = `completed`, the
-      export metadata, and the `output` entries with their download `location`s
-    - This is the same manifest a synchronous call would return; there is no
-      `303 See Other` redirect and no separate result URL
-5. **Error Handling**: If the export fails, the status poll returns the relevant
-   error status code (e.g. `500 Internal Server Error`) with an
-   `OperationOutcome` body. Polling-transport errors and operation failures are
-   distinguished by the status code on the poll response itself.
+   - **In Progress**: `202 Accepted` with optional Parameters resource for interim status
+   - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
+   - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
+   - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
+   - **Excessive Polling**: Server MAY respond with `429 Too Many Requests`; clients SHOULD apply exponential backoff
+4. **Completion**: When the export has finished - whether it succeeded or
+   failed - the status poll returns:
+   - `303 See Other` status code
+   - `Location` header with the absolute result URL
+   - An empty body
+   - The status endpoint reflects polling machinery only; it never communicates
+     the job's outcome. Clients MUST treat the status and result URLs as opaque
+     values.
+5. **Result Retrieval**: Client fetches the result URL with `GET`:
+   - **Success**: `200 OK` with the manifest `Parameters` resource in the body
+     containing `status` = `completed`, the export metadata, and the `output`
+     entries with their download `location`s
+   - **Failure**: the relevant error status code (e.g.
+     `500 Internal Server Error`) with an `OperationOutcome` body explaining
+     the failure; repeated fetches return the same outcome within the validity
+     window
 6. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
-    - Client sends `DELETE` request to the status polling URL
-    - Server responds with `202 Accepted`
-    - Subsequent status requests return `404 Not Found`
-    - Server SHOULD clean up any partial results
+   - Client sends `DELETE` request to the status polling URL
+   - Server responds with `202 Accepted`
+   - Subsequent status requests return `404 Not Found`
+   - Server SHOULD clean up any partial results
 7. **Result Lifetime**:
-   The completed status URL (which returns the manifest) and the
+   The result URL (which returns the manifest) and the
    `output.location` download URLs SHALL remain valid for at least 24 hours after
    export completion:
-    - Servers SHOULD support multiple retrievals of the completed manifest
-    - Servers MAY include an `Expires` header to indicate when the URLs expire
-    - Clients should retrieve results promptly but can retry within the validity window
+   - Servers SHOULD support multiple retrievals of the result
+   - Servers MAY include an `Expires` header to indicate when the URLs expire
+   - Clients should retrieve results promptly but can retry within the validity window
 8. **Access Control**:
-   Servers SHALL protect status and download URLs with appropriate access controls:
-    - Same authorization context as the original request, OR
-    - Non-guessable URLs (e.g., cryptographically random tokens)
-    - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
+   Servers SHALL protect status, result, and download URLs with appropriate access controls:
+   - Same authorization context as the original request (servers SHOULD limit
+     access to the client that initiated the export), OR
+   - Non-guessable URLs (e.g., cryptographically random tokens)
+   - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
 9. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
 
 #### Examples
@@ -703,7 +721,23 @@ Accept: application/fhir+json
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
 ```
 
-The status poll returns `200 OK` with the manifest in the body; there is no redirect:
+The export has finished, so the status poll returns `303 See Other` with the result URL in the `Location` header and no body:
+
+```http
+HTTP/1.1 303 See Other
+Location: https://example.com/fhir/export/550e8400-e29b-41d4-a716-446655440000/result
+```
+
+**Step 6: Fetch the Result**
+
+Client fetches the result URL; the manifest `Parameters` resource is returned:
+
+```http
+GET /fhir/export/550e8400-e29b-41d4-a716-446655440000/result HTTP/1.1
+Host: example.com
+Accept: application/fhir+json
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
+```
 
 ```http
 HTTP/1.1 200 OK
@@ -758,7 +792,7 @@ Expires: Wed, 04 Mar 2026 14:30:42 GMT
 }
 ```
 
-**Step 6: Download Files**
+**Step 7: Download Files**
 
 Client downloads each file:
 

--- a/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
+++ b/input/pagecontent/OperationDefinition-ViewDefinitionExport-notes.md
@@ -4,22 +4,17 @@
 
 #### Asynchronous Pattern
 
-This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html); the completion response is specified once in [Common Operation Behavior — Asynchronous Delivery](operations-common.html#asynchronous-delivery):
+This operation follows the [FHIR Asynchronous Interaction Request Pattern](https://build.fhir.org/ig/HL7/api-incubator-ig/branches/simplified-async-interaction/async-interaction.html); the asynchronous flow is specified once in [Common Operation Behavior - Asynchronous Delivery](operations-common.html#asynchronous-delivery):
 
 1. Client sends request with `Prefer: respond-async` header and one or more `view` parameters
 2. Server returns `202 Accepted` with `Content-Location` header pointing to status URL
 3. Client polls the status URL for export progress
 4. Server responds with `202 Accepted` while export is in progress (MAY include interim results)
-5. Upon completion, the status poll returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …) **in the response body**
-6. Client downloads the exported files from the `output.location` URLs in the manifest
+5. Once the export has finished (successfully or not), the status poll returns `303 See Other` with a `Location` header carrying the result URL and an empty body
+6. Client fetches the result URL; a successful export returns `200 OK` with the manifest `Parameters` resource (`exportId`, `status`, `output`, …), and a failed export returns the error status code with an `OperationOutcome`
+7. Client downloads the exported files from the `output.location` URLs in the manifest
 
-**Note**: This operation uses a FHIR `Parameters` resource as the manifest instead of the Bulk Data JSON manifest object to:
-
-- Provide structured status reporting and metadata
-- Allow extensible output metadata specific to export operations
-- Maintain consistency with other FHIR operations
-
-**Note**: Completion is signalled by `200 OK` with the manifest in the body of the status-poll response, as in the FHIR Asynchronous Bulk Data Request Pattern. The operation does not use a `303 See Other` redirect to a separate result resource, so standard Bulk Data clients interoperate without special handling.
+The result resource for this operation is the manifest `Parameters` resource described under [Output Parameters](#output-parameters). Clients MUST treat the status and result URLs as opaque values.
 
 ##### Async Flow Diagram
 
@@ -83,6 +78,22 @@ This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https:/
       │ └─────────────────────────────────────────┘   │
       │ ─────────────────────────────────────────────>│
       │                                               │  Step 3: Completion
+      │   ┌─────────────────────────────────────────┐ │  (303 + result URL)
+      │   │ 303 See Other                           │ │
+      │   │ Location: /result/abc123                │ │
+      │   │                                         │ │
+      │   │ (empty body)                            │ │
+      │   └─────────────────────────────────────────┘ │
+      │ <─────────────────────────────────────────────│
+      │                                               │
+      ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─┤
+      │                                               │
+      │ ┌─────────────────────────────────────────┐   │
+      │ │ GET /result/abc123                      │   │
+      │ │ Accept: application/fhir+json           │   │
+      │ └─────────────────────────────────────────┘   │
+      │ ─────────────────────────────────────────────>│
+      │                                               │  Step 4: Result fetch
       │   ┌─────────────────────────────────────────┐ │  (200 OK + manifest)
       │   │ 200 OK                                  │ │
       │   │ Content-Type: application/fhir+json    │ │
@@ -108,7 +119,7 @@ This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https:/
       │ │ GET /export/abc123/patients.ndjson      │   │
       │ └─────────────────────────────────────────┘   │
       │ ─────────────────────────────────────────────>│
-      │                                               │  Step 4: Download
+      │                                               │  Step 5: Download
       │   ┌─────────────────────────────────────────┐ │
       │   │ 200 OK                                  │ │
       │   │ Content-Type: application/x-ndjson     │ │
@@ -152,6 +163,14 @@ This operation follows the [FHIR Asynchronous Bulk Data Request Pattern](https:/
   │    │ GET /status/abc123                            │            │
   │    │ ─────────────────────────────────────────────>│            │
   │    │                                               │            │
+  │    │   303 See Other                               │            │
+  │    │   Location: /result/abc123                    │            │
+  │    │   (empty body)                                │            │
+  │    │ <─────────────────────────────────────────────│            │
+  │    │                                               │            │
+  │    │ GET /result/abc123                            │            │
+  │    │ ─────────────────────────────────────────────>│            │
+  │    │                                               │            │
   │    │   500 Internal Server Error                   │            │
   │    │   { "resourceType": "OperationOutcome",       │            │
   │    │     "issue": [{                               │            │
@@ -188,16 +207,20 @@ Optional filtering parameters:
 
 ##### Status Request
 
-- `Accept` (recommended) - Specifies the format of the status response, including the completion (`200 OK`) response that carries the manifest
+- `Accept` (recommended) - Specifies the format of interim status responses and error responses on the status URL; the completing poll returns `303 See Other` with an empty body
+
+##### Result Request
+
+- `Accept` (recommended) - Specifies the representation of the result: the manifest `Parameters` resource on success, or the `OperationOutcome` on failure
 
 ##### Header Scope
 
-Each status-poll request's headers apply to **that poll's response**. Because
-completion is delivered as `200 OK` with the manifest in the body of the
-status-poll response (there is no separate result resource), the `Accept` header
-sent on the completing poll governs the representation of the manifest. This
-allows a client to negotiate a different representation for interim status
-responses (e.g. minimal JSON) than for the final manifest if it chooses.
+Each request's headers apply to **that request's response**. Because
+completion is delivered as `303 See Other` with an empty body, the `Accept`
+header that governs the representation of the manifest is the one sent on the
+result `GET`, not the one sent on the completing status poll. This allows a
+client to negotiate a different representation for interim status responses
+(e.g. minimal JSON) than for the final manifest if it chooses.
 
 #### Parameters
 
@@ -289,8 +312,8 @@ this operation. The `fhir` format is available on the run operations only:
 - If `_format` is omitted, the server SHALL produce the export output in `ndjson`
   format.
 - When `_format` is supplied, its value SHALL take precedence over `Accept`
-  (which here negotiates the format of the _status/manifest_ responses, not the
-  exported files).
+  (which here negotiates the format of the _status and result_ responses, not
+  the exported files).
 
 ##### Patient Parameter Clarification
 
@@ -320,9 +343,10 @@ the server MAY include these resources in a response irrespective of the `_since
 
 #### Output Parameters
 
-Output parameters appear in the **completion response** — the `200 OK`
-status-poll response that carries the manifest. They are not present in the
-`202 Accepted` responses returned while the export is still in progress.
+Output parameters form the **manifest** - the `Parameters` resource returned
+with `200 OK` from the result URL after the completing poll's `303 See Other`
+redirect. They are not present in the `202 Accepted` responses returned while
+the export is still in progress.
 
 ##### Export Identifiers
 
@@ -389,25 +413,25 @@ For large exports, servers MAY partition the output into multiple files. When pa
 
 ```json
 {
-    "name": "output",
-    "part": [
-        {
-            "name": "name",
-            "valueString": "patient_demographics"
-        },
-        {
-            "name": "location",
-            "valueUri": "https://example.com/export/123/patient_demographics.part1.parquet"
-        },
-        {
-            "name": "location",
-            "valueUri": "https://example.com/export/123/patient_demographics.part2.parquet"
-        },
-        {
-            "name": "location",
-            "valueUri": "https://example.com/export/123/patient_demographics.part3.parquet"
-        }
-    ]
+  "name": "output",
+  "part": [
+    {
+      "name": "name",
+      "valueString": "patient_demographics"
+    },
+    {
+      "name": "location",
+      "valueUri": "https://example.com/export/123/patient_demographics.part1.parquet"
+    },
+    {
+      "name": "location",
+      "valueUri": "https://example.com/export/123/patient_demographics.part2.parquet"
+    },
+    {
+      "name": "location",
+      "valueUri": "https://example.com/export/123/patient_demographics.part3.parquet"
+    }
+  ]
 }
 ```
 
@@ -419,14 +443,16 @@ Clients MUST download all parts to obtain the complete dataset for a view.
 
 The $viewdefinition-export operation uses standard HTTP status codes to indicate the outcome:
 
-| Status Code               | Description          | When to Use                                                          |
-| ------------------------- | -------------------- | -------------------------------------------------------------------- |
-| 202 Accepted              | In Progress          | Export request accepted or still in progress during polling          |
-| 200 OK                    | Complete             | Export complete; the status-poll response body carries the manifest  |
-| 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers |
-| 404 Not Found             | Not Found            | ViewDefinition not found, or cancelled export status URL             |
-| 422 Unprocessable Entity  | Business Logic Error | Valid request but ViewDefinition is invalid or cannot be processed   |
-| 500 Internal Server Error | Server Error         | Unexpected server error; on a status poll, indicates operation failure |
+| Status Code               | Description          | When to Use                                                                         |
+| ------------------------- | -------------------- | ----------------------------------------------------------------------------------- |
+| 202 Accepted              | In Progress          | Export request accepted, still in progress during polling, or cancellation accepted |
+| 303 See Other             | Job Finished         | Export finished (successfully or not); `Location` header carries the result URL     |
+| 200 OK                    | Result Available     | Result URL returns the manifest `Parameters`; download URLs return the files        |
+| 400 Bad Request           | Client Error         | Invalid parameters, unsupported parameters, missing required headers                |
+| 404 Not Found             | Not Found            | ViewDefinition not found, or cancelled export status URL                            |
+| 422 Unprocessable Entity  | Business Logic Error | Valid request but ViewDefinition is invalid or cannot be processed                  |
+| 429 Too Many Requests     | Excessive Polling    | Client is polling too frequently; back off exponentially, guided by `Retry-After`   |
+| 500 Internal Server Error | Server Error         | Unexpected server error; on the result URL, the failure outcome of the export       |
 
 {:.table-data}
 
@@ -564,43 +590,51 @@ Content-Type: application/fhir+json
 
 1. **Kick-off Request**: Client sends `POST ViewDefinition/$viewdefinition-export` with `Prefer: respond-async` header.
 2. **Kick-off Response**: Server responds with:
-    - `202 Accepted` status code
-    - `Content-Location` header with the absolute URL for subsequent status requests (polling location)
-    - Parameters resource with `status` parameter set to `accepted` and `location` parameter
-    - If request is not valid or cannot be processed, server responds with `400 Bad Request` and `OperationOutcome` resource in the body.
+   - `202 Accepted` status code
+   - `Content-Location` header with the absolute URL for subsequent status requests (polling location)
+   - Parameters resource with `status` parameter set to `accepted` and `location` parameter
+   - If request is not valid or cannot be processed, server responds with `400 Bad Request` and `OperationOutcome` resource in the body.
 3. **Status Polling**: Client polls the polling location to get status of the export:
-    - **In Progress**: `202 Accepted` with optional Parameters resource for interim status
-    - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
-    - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
-    - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
-4. **Completion**: When the export is ready, the status poll returns:
-    - `200 OK` status code
-    - A `Parameters` resource in the body containing `status` = `completed`, the
-      export metadata, and the `output` entries with their download `location`s
-    - This is the same manifest a synchronous call would return; there is no
-      `303 See Other` redirect and no separate result URL
-5. **Error Handling**: If the export fails, the status poll returns the relevant
-   error status code (e.g. `500 Internal Server Error`) with an
-   `OperationOutcome` body. Polling-transport errors and operation failures are
-   distinguished by the status code on the poll response itself.
+   - **In Progress**: `202 Accepted` with optional Parameters resource for interim status
+   - **Progress Updates**: Server MAY include `X-Progress` header to indicate completion percentage
+   - **Retry-After**: Server SHOULD include `Retry-After` header to indicate when to retry
+   - **Interim Results**: Server MAY include partial/interim results in response body (implementation-defined)
+   - **Excessive Polling**: Server MAY respond with `429 Too Many Requests`; clients SHOULD apply exponential backoff
+4. **Completion**: When the export has finished - whether it succeeded or
+   failed - the status poll returns:
+   - `303 See Other` status code
+   - `Location` header with the absolute result URL
+   - An empty body
+   - The status endpoint reflects polling machinery only; it never communicates
+     the job's outcome. Clients MUST treat the status and result URLs as opaque
+     values.
+5. **Result Retrieval**: Client fetches the result URL with `GET`:
+   - **Success**: `200 OK` with the manifest `Parameters` resource in the body
+     containing `status` = `completed`, the export metadata, and the `output`
+     entries with their download `location`s
+   - **Failure**: the relevant error status code (e.g.
+     `500 Internal Server Error`) with an `OperationOutcome` body explaining
+     the failure; repeated fetches return the same outcome within the validity
+     window
 6. **Cancellation** (Recommended):
    Servers SHOULD support export cancellation via DELETE request to the status URL:
-    - Client sends `DELETE` request to the status polling URL
-    - Server responds with `202 Accepted`
-    - Subsequent status requests return `404 Not Found`
-    - Server SHOULD clean up any partial results
+   - Client sends `DELETE` request to the status polling URL
+   - Server responds with `202 Accepted`
+   - Subsequent status requests return `404 Not Found`
+   - Server SHOULD clean up any partial results
 7. **Result Lifetime**:
-   The completed status URL (which returns the manifest) and the
+   The result URL (which returns the manifest) and the
    `output.location` download URLs SHALL remain valid for at least 24 hours after
    export completion:
-    - Servers SHOULD support multiple retrievals of the completed manifest
-    - Servers MAY include an `Expires` header to indicate when the URLs expire
-    - Clients should retrieve results promptly but can retry within the validity window
+   - Servers SHOULD support multiple retrievals of the result
+   - Servers MAY include an `Expires` header to indicate when the URLs expire
+   - Clients should retrieve results promptly but can retry within the validity window
 8. **Access Control**:
-   Servers SHALL protect status and download URLs with appropriate access controls:
-    - Same authorization context as the original request, OR
-    - Non-guessable URLs (e.g., cryptographically random tokens)
-    - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
+   Servers SHALL protect status, result, and download URLs with appropriate access controls:
+   - Same authorization context as the original request (servers SHOULD limit
+     access to the client that initiated the export), OR
+   - Non-guessable URLs (e.g., cryptographically random tokens)
+   - Unauthorized access attempts return `401 Unauthorized` or `403 Forbidden`
 9. **File Download**: Client downloads the output from URLs in the `output.location` parameters.
 
 #### Examples
@@ -842,7 +876,23 @@ Accept: application/fhir+json
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
 ```
 
-The status poll returns `200 OK` with the manifest in the body (identical to what a synchronous call would return); there is no redirect:
+The export has finished, so the status poll returns `303 See Other` with the result URL in the `Location` header and no body:
+
+```http
+HTTP/1.1 303 See Other
+Location: https://example.com/fhir/export/550e8400-e29b-41d4-a716-446655440000/result
+```
+
+**Step 6: Fetch the Result**
+
+Client fetches the result URL; the manifest `Parameters` resource is returned:
+
+```http
+GET /fhir/export/550e8400-e29b-41d4-a716-446655440000/result HTTP/1.1
+Host: example.com
+Accept: application/fhir+json
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGc...
+```
 
 ```http
 HTTP/1.1 200 OK
@@ -914,7 +964,7 @@ Expires: Fri, 16 Jan 2026 14:30:42 GMT
 }
 ```
 
-**Step 6: Download Files**
+**Step 7: Download Files**
 
 Client downloads each file:
 

--- a/input/pagecontent/operations-common.md
+++ b/input/pagecontent/operations-common.md
@@ -121,8 +121,8 @@ rather than silently returning raw bytes under a FHIR media type. Support for
 the envelope representation per format SHOULD be documented in the
 CapabilityStatement.
 
-These two axes are distinct: Axis 1 decides *what* is encoded, Axis 2 decides
-*how* it is wrapped.
+These two axes are distinct: Axis 1 decides _what_ is encoded, Axis 2 decides
+_how_ it is wrapped.
 
 ## Streaming and Transfer Encoding {#streaming}
 
@@ -136,7 +136,7 @@ Two further concepts are independent of each other and of the format:
 
 1. **Transfer framing** - `Transfer-Encoding: chunked` (RFC 9112 §7.1) is an
    HTTP/1.1 message-framing mechanism. It is independent of `Content-Type` and
-   of `_format`: *any* payload - CSV, JSON, NDJSON, parquet,
+   of `_format`: _any_ payload - CSV, JSON, NDJSON, parquet,
    `application/octet-stream`, or a `Binary` envelope - MAY be sent chunked. The
    choice between `Content-Length` and chunked framing depends solely on whether
    the server knows the body size before emitting the first byte, never on the
@@ -154,26 +154,48 @@ Two further concepts are independent of each other and of the format:
 ## Asynchronous Delivery {#asynchronous-delivery}
 
 The two export operations conform to the
-[FHIR Asynchronous Bulk Data Request Pattern](https://www.hl7.org/fhir/async-bulk.html).
-In particular, on completion they follow that pattern's completion response
-exactly:
+[FHIR Asynchronous Interaction Request Pattern](https://build.fhir.org/ig/HL7/api-incubator-ig/branches/simplified-async-interaction/async-interaction.html):
 
-- **Kick-off** → `202 Accepted` with a `Content-Location` header carrying the
-  status (polling) URL.
-- **Polling while processing** → `202 Accepted`, optionally with `Retry-After`
-  and `X-Progress`, and an optional interim status body.
-- **Completion** → `200 OK` whose body is the manifest `Parameters` resource
+- **Kick-off** → the client sends the request with a `Prefer: respond-async`
+  header; the server responds `202 Accepted` with a `Content-Location` header
+  carrying the status (polling) URL. An informative `Parameters` body MAY be
+  included. Invalid requests (bad or unsupported parameters, authorisation
+  failures, referenced resources not found) are rejected synchronously with the
+  relevant `4xx`/`5xx` status code and an `OperationOutcome` body - rejection
+  is never deferred to the status URL.
+- **Polling while processing** → `GET` on the status URL returns
+  `202 Accepted`, with a `Retry-After` header (recommended), an `X-Progress`
+  header (optional), and an optional, informative, implementation-defined
+  interim status body. A server MAY respond `429 Too Many Requests` to a client
+  that polls excessively; clients SHOULD apply exponential backoff, guided by
+  `Retry-After` where present.
+- **Completion and failure** → once the job has finished - whether it succeeded
+  or failed - the status poll returns `303 See Other` with a `Location` header
+  carrying the result URL and an empty body. The status endpoint reflects
+  polling machinery only; it never communicates the job's outcome.
+- **Result retrieval** → the client fetches the result URL with `GET`. For a
+  successful export, the result is the manifest `Parameters` resource
   (`exportId`, `status`, `_format`, the export-timing parameters, and the
-  repeating `output` entries with their `location` download URLs). The manifest
-  is returned **in the body of the status-poll response**; there is no
-  `303 See Other` redirect and no separate result resource to follow.
-- **Failure** → the status poll returns the relevant error status code (e.g.
-  `500 Internal Server Error`) with an `OperationOutcome` body.
+  repeating `output` entries with their `location` download URLs), returned
+  with `200 OK`. For a failed export, the result URL returns the relevant error
+  status code (e.g. `500 Internal Server Error`) with an `OperationOutcome`
+  body explaining the failure; repeated fetches return the same outcome within
+  the validity window.
 
-The deliberate deviation from that pattern is the manifest's representation:
-it is a FHIR `Parameters` resource rather than the Bulk Data JSON manifest
-object. The flow, status codes, and headers are otherwise as the pattern
-specifies.
+Clients MUST treat the status and result URLs as opaque values. Note that many
+HTTP libraries follow a `303` response to a `GET` automatically, so a polling
+client may transparently receive the result response; this is benign.
+
+The result URL and all `output.location` download URLs SHALL remain valid for
+at least 24 hours after job completion. Servers SHOULD support multiple
+retrievals within that window and MAY include an `Expires` header indicating
+when the URLs expire.
+
+The same access control applies to status-URL and result-URL requests as to
+the original kick-off request, and servers SHOULD limit access to the client
+that initiated the job; non-guessable URLs (e.g. cryptographically random
+tokens) remain documented as an alternative control. Unauthorised access
+attempts return `401 Unauthorized` or `403 Forbidden`.
 
 File downloads referenced by `output.location` are independent HTTP responses;
 their transfer framing is governed by HTTP itself and is not constrained by

--- a/input/pagecontent/operations.md
+++ b/input/pagecontent/operations.md
@@ -39,12 +39,13 @@ And use standard tools like Apache Spark, AWS Athena or other tools to analyze d
    a list of ViewDefinitions to the server with `Prefer: respond-async` header.
 2. The server returns `202 Accepted` with `Content-Location` header pointing to status URL.
 3. The client polls the status URL:
-    - Server returns `202 Accepted` while processing (MAY include interim results)
-    - Server returns `200 OK` with the manifest (output URLs) in the body when complete
-4. The client reads the output URLs from the completion manifest.
-5. The client can then:
-    - Download exported files from the output URLs
-    - Load them into a data warehouse or analyze with tools like Apache Spark or Amazon Athena
+   - Server returns `202 Accepted` while processing (MAY include interim results)
+   - Server returns `303 See Other` with a `Location` header carrying the result URL when the export has finished
+4. The client fetches the result URL, which returns the manifest (output URLs) with `200 OK`.
+5. The client reads the output URLs from the manifest.
+6. The client can then:
+   - Download exported files from the output URLs
+   - Load them into a data warehouse or analyze with tools like Apache Spark or Amazon Athena
 
 [See Async Bulk Export](OperationDefinition-ViewDefinitionExport.html)
 
@@ -58,8 +59,8 @@ observations and medications as they are recorded.
 
 1. The client initiates a real-time evaluation of a ViewDefinition by submitting it to the server.
 2. The server:
-    - Processes the ViewDefinition
-    - Responds with the results of the evaluation
+   - Processes the ViewDefinition
+   - Responds with the results of the evaluation
 3. The client can process streamed results on fly.
 
 [See Run ViewDefinition](OperationDefinition-ViewDefinitionRun.html)
@@ -72,8 +73,8 @@ Developers or developer tools can test and refine ViewDefinitions interactively 
 
 1. The client initiates a real-time evaluation of a ViewDefinition by submitting it to the server.
 2. The server:
-    - Processes the ViewDefinition
-    - Responds with the results of the evaluation
+   - Processes the ViewDefinition
+   - Responds with the results of the evaluation
 
 [See Run ViewDefinition](OperationDefinition-ViewDefinitionRun.html)
 
@@ -87,9 +88,9 @@ Administrative bodies can request bulk reports for different populations and met
 
 1. The client initiates an asynchronous request to run queries on specific views.
 2. The server:
-    - Processes the request
-    - Builds views and runs queries
-    - Responds with the results
+   - Processes the request
+   - Builds views and runs queries
+   - Responds with the results
 3. The client can poll results
 
 [See Run Bulk Queries](OperationDefinition-SQLQueryRun.html)
@@ -97,9 +98,9 @@ Administrative bodies can request bulk reports for different populations and met
 ## API
 
 Behaviour shared by the four data operations (`$viewdefinition-run`,
-`$sqlquery-run`, `$viewdefinition-export`, `$sqlquery-export`) — the output
+`$sqlquery-run`, `$viewdefinition-export`, `$sqlquery-export`) - the output
 format set, return representation, content negotiation, transfer framing, and
-the asynchronous completion response — is specified once in
+the asynchronous delivery flow - is specified once in
 [Common Operation Behavior](operations-common.html). The operation pages below
 reference it rather than restating it.
 


### PR DESCRIPTION
Aligns the two async export operations (`$viewdefinition-export` and `$sqlquery-export`) to the simplified [FHIR Asynchronous Interaction Request Pattern](https://build.fhir.org/ig/HL7/api-incubator-ig/branches/simplified-async-interaction/async-interaction.html), replacing the Bulk Data pattern the spec previously cited.

Completion and failure are now both signalled by a `303 See Other` redirect from the status poll to a separate result URL. The status poll body is empty; the result URL returns the manifest `Parameters` with `200 OK` on success, or the error status with an `OperationOutcome` on failure.

Updated across the IG source: the shared Asynchronous Delivery section, both export operation pages (prose, diagrams, headers, output framing, status-code tables, worked examples), the operations overview, the FSH description, and the SQLQuery export intro. Also adds `429 Too Many Requests` polling guidance, the opaque-URL requirement, and the 24-hour result lifetime applied to the result and download URLs.

The manifest shape is unchanged - it is just described as the resource returned from the result URL rather than the status-poll body. The export operations are not in any published release, so this is not a breaking change. The IG builds cleanly (`errs: 0`, no unsuppressed warnings).

Companion issues, per constitution principle III and the citation follow-up:

- Async-flow conformance behaviour to test: FHIR/sql-on-fhir.js#3
- Swap the branch CI-build URL for the permanent one after the incubator branch merges: #368

I'll also raise this on the Analytics on FHIR Zulip stream and at the weekly meeting.
