### PR TITLE
Replace build.fhir.org links with published URLs

### DIFF
--- a/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryExport-notes.md
@@ -234,7 +234,7 @@ the server MAY include these resources in a response irrespective of the `_since
 Query parameters are passed as a nested `Parameters` resource within each
 `query` repetition (per-query binding via the `parameters` part), following the
 same pattern as [`$sqlquery-run`](OperationDefinition-SQLQueryRun.html) and the
-[CQL `$evaluate` operation](https://build.fhir.org/ig/HL7/cql-ig/en/OperationDefinition-cql-library-evaluate.html).
+[CQL `$evaluate` operation](https://hl7.org/fhir/uv/cql/OperationDefinition-cql-library-evaluate.html).
 See [Parameter Types](StructureDefinition-SQLQuery.html#parameter-types) on the
 SQLQuery profile for the binding rules and the mapping from
 `Library.parameter.type` to the `value[x]` element to use.

--- a/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
+++ b/input/pagecontent/OperationDefinition-SQLQueryRun-notes.md
@@ -342,7 +342,7 @@ type within the SQL query.
 
 Query parameters are passed as a nested `Parameters` resource, following the
 same pattern as the
-[CQL `$evaluate` operation](https://build.fhir.org/ig/HL7/cql-ig/en/OperationDefinition-cql-library-evaluate.html).
+[CQL `$evaluate` operation](https://hl7.org/fhir/uv/cql/OperationDefinition-cql-library-evaluate.html).
 See [Parameter Types](StructureDefinition-SQLQuery.html#parameter-types) on the
 SQLQuery profile for the binding rules and the mapping from
 `Library.parameter.type` to the `value[x]` element to use.

--- a/input/pagecontent/functional-model.md
+++ b/input/pagecontent/functional-model.md
@@ -113,7 +113,7 @@ The resulting output:
 ## The FHIRPath Subset
 
 ViewDefinitions
-use [minimal subset of FHIRPath](https://build.fhir.org/ig/HL7/sql-on-fhir/StructureDefinition-ViewDefinition.html#fhirpath-functionality)
+use [minimal subset of FHIRPath](StructureDefinition-ViewDefinition.html#fhirpath-functionality)
 to make implementation as simple as possible.
 
 The specification also introduces two special functions:


### PR DESCRIPTION
Fixes #379.

Three narrative links pointed at the unstable `build.fhir.org` CI build, which breaks the HL7 FHIR IG Quality Criteria requirement for permanent published targets. This replaces them:

- The CQL `$evaluate` links in the `$sqlquery-run` and `$sqlquery-export` operation notes now point to the published CQL IG page (`https://hl7.org/fhir/uv/cql/OperationDefinition-cql-library-evaluate.html`, HTTP 200). The unversioned canonical path is used so it always resolves to the current published release.
- The "minimal subset of FHIRPath" self-reference on the functional model page is now a relative link (`StructureDefinition-ViewDefinition.html#fhirpath-functionality`), so it stays within whichever build is being viewed.

The three intentional exclusions called out in the issue are left untouched: the experimental-section FHIRPath function links in the ShareableViewDefinition notes and the commented-out boilerplate URLs in `sushi-config.yaml`.

Verified with a repo-wide grep (only the five intentional matches remain), a full IG build (0 broken links, no new warnings, no new suppressions), and a manual check that the rendered relative link lands on the FHIRPath Functionality anchor.

Note: this branch does not build error-free, but the errors are pre-existing on `main` (8 missing-OID errors on the project CodeSystems/ValueSets) and unrelated to this change; the error set is identical to a fresh build of `main`. Those are worth triaging separately.